### PR TITLE
Add matte material with parameter "color"

### DIFF
--- a/examples/example_device/CMakeLists.txt
+++ b/examples/example_device/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(${PROJECT_NAME} SHARED
   frame/Frame.cpp
 
   material/Material.cpp
+  material/Matte.cpp
   material/OBJ.cpp
 
   renderer/AmbientOcclusion.cpp

--- a/examples/example_device/material/Material.cpp
+++ b/examples/example_device/material/Material.cpp
@@ -4,6 +4,7 @@
 #include "Material.h"
 // specific types
 #include "OBJ.h"
+#include "Matte.h"
 
 namespace anari {
 namespace example_device {
@@ -15,7 +16,7 @@ static void init()
   g_materials = std::make_unique<FactoryMap<Material>>();
 
   g_materials->emplace("obj", []() -> Material * { return new OBJ; });
-  g_materials->emplace("matte", []() -> Material * { return new OBJ; });
+  g_materials->emplace("matte", []() -> Material * { return new Matte; });
 }
 
 Material *Material::createInstance(const char *type)

--- a/examples/example_device/material/Matte.cpp
+++ b/examples/example_device/material/Matte.cpp
@@ -1,0 +1,20 @@
+// Copyright 2021 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Matte.h"
+
+namespace anari {
+namespace example_device {
+
+void Matte::commit()
+{
+  m_color = getParam<vec3>("color", vec3(.8f,.8f,.8f));
+}
+
+vec3 Matte::diffuse() const
+{
+  return m_color;
+}
+
+} // namespace example_device
+} // namespace anari

--- a/examples/example_device/material/Matte.h
+++ b/examples/example_device/material/Matte.h
@@ -1,0 +1,24 @@
+// Copyright 2021 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Material.h"
+
+namespace anari {
+namespace example_device {
+
+struct Matte : public Material
+{
+  Matte() = default;
+
+  void commit() override;
+
+  vec3 diffuse() const override;
+
+ private:
+   vec3 m_color{.8f,.8f,.8f};
+};
+
+} // namespace example_device
+} // namespace anari


### PR DESCRIPTION
Would you be willing to merge this PR which adds a dedicated subclass for the matte material? It's mostly that currently, with matte being used as an alias for OBJ, one has to set the color parameter via "kd", not "color", and my own sample code then not being compliant with the standard. 

FWIW, the only use of matte that I can see in the SDK is found in `anariTuturial.cpp`, where the diffuse color parameter is not set on the material; i.e., the change set shouldn't break existing behavior.