### PR TITLE
Rename "viewer" to anariViewer to match app naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ get the library to load. For example it can be run with:
 
 ```bash
 % export ANARI_LIBRARY=example
-% ./viewer /path/to/some/file.obj
+% ./anariViewer /path/to/some/file.obj
 ```
 
 Alternatively, either `--library` or `-l` can be used to override the library to

--- a/examples/viewer/CMakeLists.txt
+++ b/examples/viewer/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## Copyright 2021 The Khronos Group
 ## SPDX-License-Identifier: Apache-2.0
 
-project(viewer LANGUAGES CXX)
+project(anariViewer LANGUAGES CXX)
 
 ## Build viewer ##
 

--- a/examples/viewer/main.cpp
+++ b/examples/viewer/main.cpp
@@ -86,7 +86,7 @@ static void initializeANARI()
 /******************************************************************/
 void printUsage()
 {
-  std::cout << "./viewer [{--help|-h}] [{--library|-l} <ANARI library>] [.obj intput file]" << std::endl;
+  std::cout << "./anariViewer [{--help|-h}] [{--library|-l} <ANARI library>] [.obj intput file]" << std::endl;
 }
 
 /******************************************************************/


### PR DESCRIPTION
The other applications are all named `anari*` while the viewer was just named `viewer`. This PR renames the app to `anariViewer` to match the naming convention of the other apps.