### PR TITLE
fixes

### DIFF
--- a/libs/anari_test_scenes/scenes/gravity_spheres_volume.cpp
+++ b/libs/anari_test_scenes/scenes/gravity_spheres_volume.cpp
@@ -174,8 +174,7 @@ void GravityVolume::commit()
         d, m_world, "surface", anari::newArray(d, &surface));
     anari::release(d, surface);
   } else {
-    anari::setParameter<anari::Array1D>(
-        d, m_world, "surface", ANARI_INVALID_HANDLE);
+    anari::unsetParameter(d, m_world, "surface");
   }
 
   anari::setAndReleaseParameter(

--- a/libs/anari_utilities/include/anari/detail/IntrusivePtr.h
+++ b/libs/anari_utilities/include/anari/detail/IntrusivePtr.h
@@ -173,6 +173,8 @@ inline IntrusivePtr<T> &IntrusivePtr<T>::operator=(const IntrusivePtr &input)
 template <typename T>
 inline IntrusivePtr<T> &IntrusivePtr<T>::operator=(IntrusivePtr &&input)
 {
+  if (ptr)
+    ptr->refDec();
   ptr = input.ptr;
   input.ptr = nullptr;
   return *this;


### PR DESCRIPTION
- Fix mem leak in `IntrusivePtr` move operator
- Use `unsetParameter` (instead of setting `INVALID_HANDLE`)
