### PR TITLE
Front-end library, C99 backends

### DIFF
--- a/libs/anari/API.cpp
+++ b/libs/anari/API.cpp
@@ -128,8 +128,6 @@ extern "C" ANARIDevice anariNewDevice(
   if (!_d)
     return nullptr;
   auto &d = deviceRef(_d);
-  d.m_defaultStatusCB = lib.defaultStatusCB();
-  d.m_defaultStatusCBUserPtr = lib.defaultStatusCBUserPtr();
   return _d;
 }
 ANARI_CATCH_END(nullptr)
@@ -157,9 +155,6 @@ extern "C" const char **anariGetObjectSubtypes(ANARILibrary l,
 {
   THROW_IF_NULL_STRING(deviceSubtype);
 
-  if (std::string(deviceSubtype) == "default")
-    deviceSubtype = libraryRef(l).defaultDeviceName();
-
   return libraryRef(l).getObjectSubtypes(deviceSubtype, objectType);
 }
 ANARI_CATCH_END(nullptr)
@@ -171,9 +166,6 @@ extern "C" const ANARIParameter *anariGetObjectParameters(ANARILibrary l,
 {
   THROW_IF_NULL_STRING(deviceSubtype);
   THROW_IF_NULL_STRING(objectSubtype);
-
-  if (std::string(deviceSubtype) == "default")
-    deviceSubtype = libraryRef(l).defaultDeviceName();
 
   return libraryRef(l).getObjectParameters(
       deviceSubtype, objectSubtype, objectType);
@@ -194,10 +186,7 @@ extern "C" const void *anariGetParameterInfo(ANARILibrary l,
   THROW_IF_NULL_STRING(parameterName);
   THROW_IF_NULL_STRING(parameterType);
 
-  if (std::string(deviceSubtype) == "default")
-    deviceSubtype = libraryRef(l).defaultDeviceName();
-
-  return libraryRef(l).getParameterProperty(deviceSubtype,
+  return libraryRef(l).getParameterInfo(deviceSubtype,
       objectSubtype,
       objectType,
       parameterName,

--- a/libs/anari/include/anari/detail/Backend.h
+++ b/libs/anari/include/anari/detail/Backend.h
@@ -1,0 +1,55 @@
+// Copyright 2021 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "anari/anari.h"
+
+struct ANARIBackendLibraryData;
+typedef ANARIBackendLibraryData *(
+    ANARIBackendLoadLibrary)(ANARIStatusCallback defaultStatusCB,
+    void *defaultStatusCBUserPtr);
+typedef void ANARIBackendLibrary;
+typedef void (*ANARIBackendUnloadLibrary)(ANARIBackendLibrary *);
+typedef const char **(*ANARIBackendGetDeviceSubtypes)(ANARIBackendLibrary *);
+typedef const char **(*ANARIBackendGetObjectSubtypes)(
+    ANARIBackendLibrary *, const char *deviceSubtype, ANARIDataType objectType);
+typedef const ANARIParameter *(*ANARIBackendGetObjectParameters)(
+    ANARIBackendLibrary *,
+    const char *deviceSubtype,
+    const char *objectSubtype,
+    ANARIDataType objectType);
+typedef const void *(*ANARIBackendGetParameterInfo)(ANARIBackendLibrary *,
+    const char *deviceSubtype,
+    const char *objectSubtype,
+    ANARIDataType objectType,
+    const char *parameterName,
+    ANARIDataType parameterType,
+    const char *infoName,
+    ANARIDataType infoType);
+struct ANARIBackendDevice;
+// typedef ANARIBackendDevice *(*ANARIBackendNewDevice)(
+typedef ANARIDevice (*ANARIBackendNewDevice)(
+    ANARIBackendLibrary *, const char *deviceType);
+
+struct ANARIBackendLibraryData
+{
+  ANARIBackendLibrary *data;
+  ANARIBackendUnloadLibrary unloadLibrary;
+  ANARIBackendGetDeviceSubtypes getDeviceSubtypes;
+  ANARIBackendGetObjectSubtypes getObjectSubtypes;
+  ANARIBackendGetObjectParameters getObjectParameters;
+  ANARIBackendGetParameterInfo getParameterInfo;
+  ANARIBackendNewDevice newDevice;
+};
+
+#define ANARIBACKEND_DEFINE_LOAD_LIBRARY(                                      \
+    libName, defaultStatusCB, defaultStatusCBUserPtr)                          \
+  ANARIBackendLibraryData *anaribackend_load_library_##libName(                \
+      ANARIStatusCallback defaultStatusCB, void *defaultStatusCBUserPtr)
+
+// backends may append user data
+struct ANARIBackendDevice
+{
+  // TODO
+};

--- a/libs/anari/include/anari/detail/Library.h
+++ b/libs/anari/include/anari/detail/Library.h
@@ -3,11 +3,10 @@
 
 #pragma once
 
-// anari
+#include <string>
 #include "anari/anari.h"
 #include "anari/anari_cpp/Traits.h"
-// std
-#include <string>
+#include "anari/detail/Backend.h"
 
 namespace anari {
 
@@ -18,14 +17,9 @@ void freeLibrary(void *lib);
 struct ANARI_INTERFACE Library
 {
   Library(
-      const char *name, ANARIStatusCallback defaultStatusCB, void *statusCBPtr);
+      std::string name, ANARIStatusCallback defaultStatusCB, void *statusCBPtr);
   ~Library();
 
-  void *libraryData() const;
-
-  ANARIDevice newDevice(const char *subtype) const;
-
-  const char *defaultDeviceName() const;
   ANARIStatusCallback defaultStatusCB() const;
   void *defaultStatusCBUserPtr() const;
 
@@ -38,7 +32,7 @@ struct ANARI_INTERFACE Library
   const ANARIParameter *getObjectParameters(const char *deviceSubtype,
       const char *objectSubtype,
       ANARIDataType objectType);
-  const void *getParameterProperty(const char *deviceSubtype,
+  const void *getParameterInfo(const char *deviceSubtype,
       const char *objectSubtype,
       ANARIDataType objectType,
       const char *parameterName,
@@ -46,106 +40,14 @@ struct ANARI_INTERFACE Library
       const char *propertyName,
       ANARIDataType propertyType);
 
+  ANARIDevice newDevice(const char *subtype) const;
+
  private:
-  void *m_lib{nullptr};
-  void *m_libraryData{nullptr};
-
+  const char *replaceDefaultDeviceName(const char *deviceSubtype) const;
   std::string m_defaultDeviceName;
-  ANARIStatusCallback m_defaultStatusCB{nullptr};
-  void *m_defaultStatusCBUserPtr{nullptr};
-
-  using NewDeviceFcn = ANARIDevice (*)(const char *);
-  NewDeviceFcn m_newDeviceFcn{nullptr};
-
-  using FreeFcn = void (*)(void *);
-  FreeFcn m_freeFcn{nullptr};
-
-  using ModuleFcn = void (*)(void *, const char *);
-  ModuleFcn m_loadModuleFcn{nullptr};
-  ModuleFcn m_unloadModuleFcn{nullptr};
-
-  using GetDeviceSubtypesFcn = const char **(*)(void *);
-  GetDeviceSubtypesFcn m_getDeviceSubtypesFcn{nullptr};
-
-  using GetObjectSubtypesFcn = const char **(*)(void *,
-      const char *,
-      ANARIDataType);
-  GetObjectSubtypesFcn m_getObjectSubtypesFcn{nullptr};
-
-  using GetObjectParametersFcn = const ANARIParameter *(*)(void *,
-      const char *,
-      const char *,
-      ANARIDataType);
-  GetObjectParametersFcn m_getObjectParametersFcn{nullptr};
-
-  using GetObjectParameterPropertyFcn = const char **(*)(void *,
-      const char *,
-      const char *,
-      ANARIDataType,
-      const char *,
-      ANARIDataType,
-      const char *,
-      ANARIDataType);
-  GetObjectParameterPropertyFcn m_getObjectParameterPropertyFcn{nullptr};
+  void *m_handle{nullptr};
+  ANARIBackendLibraryData *m_lib{nullptr};
 };
-
-// [REQUIRED] Define the function which allocates Device objects by subtype
-#define ANARI_DEFINE_LIBRARY_NEW_DEVICE(libname, type)                         \
-  ANARIDevice anari_library_##libname##_new_device(const char *type)
-
-// [OPTIONAL] Define the initialization function when library is loaded.
-#define ANARI_DEFINE_LIBRARY_INIT(libname) void anari_library_##libname##_init()
-
-// [OPTIONAL] Define the function which allocates library-specific storage on
-//            construction (after init).
-#define ANARI_DEFINE_LIBRARY_ALLOCATE(libname)                                 \
-  void *anari_library_##libname##_allocate()
-
-// [OPTIONAL] Define the function which frees library-specific storage on
-//            destruction.
-#define ANARI_DEFINE_LIBRARY_FREE(libname, libdata)                            \
-  void anari_library_##libname##_free(void *libdata)
-
-// [OPTIONAL] Define the function which loads a library-specific module.
-#define ANARI_DEFINE_LIBRARY_LOAD_MODULE(libname, libdata, modname)            \
-  void anari_library_##libname##_load_module(void *libdata, const char *modname)
-
-// [OPTIONAL] Define the function which unloads a library-specific module.
-#define ANARI_DEFINE_LIBRARY_UNLOAD_MODULE(libname, libdata, modname)          \
-  void anari_library_##libname##_unload_module(                                \
-      void *libdata, const char *modname)
-
-// [OPTIONAL] Define introspection functions.
-#define ANARI_DEFINE_LIBRARY_GET_DEVICE_SUBTYPES(libname, libdata)             \
-  const char **anari_library_##libname##_get_device_subtypes(void *libdata)
-#define ANARI_DEFINE_LIBRARY_GET_OBJECT_SUBTYPES(                              \
-    libname, libdata, deviceSubtype, objectType)                               \
-  const char **anari_library_##libname##_get_object_subtypes(                  \
-      void *libdata, const char *deviceSubtype, ANARIDataType objectType)
-#define ANARI_DEFINE_LIBRARY_GET_OBJECT_PARAMETERS(                            \
-    libname, libdata, deviceSubtype, objectSubtype, objectType)                \
-  const ANARIParameter *anari_library_##libname##_get_object_parameters(       \
-      void *libdata,                                                           \
-      const char *deviceSubtype,                                               \
-      const char *objectSubtype,                                               \
-      ANARIDataType objectType)
-#define ANARI_DEFINE_LIBRARY_GET_PARAMETER_PROPERTY(libname,                   \
-    libdata,                                                                   \
-    deviceSubtype,                                                             \
-    objectSubtype,                                                             \
-    objectType,                                                                \
-    parameterName,                                                             \
-    parameterType,                                                             \
-    propertyName,                                                              \
-    propertyType)                                                              \
-  const void *anari_library_##libname##_get_parameter_property(void *libdata,  \
-      const char *deviceSubtype,                                               \
-      const char *objectSubtype,                                               \
-      ANARIDataType objectType,                                                \
-      const char *parameterName,                                               \
-      ANARIDataType parameterType,                                             \
-      const char *propertyName,                                                \
-      ANARIDataType propertyType)
 
 ANARI_TYPEFOR_SPECIALIZATION(Library *, ANARI_LIBRARY);
 


### PR DESCRIPTION
In the spec we have (bold from me)
> The ANARI API is specified as a C99 API in order to provide **compiler-independent linkage**

and
> ANARI back-end devices are created by standard implementors and are expected to be
**distributed, installed, or upgraded independently of the standard API header and front-end library**.

I fear this cannot hold when using C++ for the backend API (i.e., implementation directly deriving from the SDK `anari::Device`): there is no C++ ABI even on the same platform. For example, MSVC has the opposite ordering in the *vtable* than gcc. [MSVC even is not compatible to itself](https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-170) (across versions, thought it seems to be better since 2015).
Besides vtable ordering another issue to consider is *exception propagation* (which we currently use to catch exceptions thrown in backends centrally in the front-end lib).

Furthermore, current SDK implementation is mixing concepts: `Device` uses virtual functions and implementations derive from it, while `Library` uses "getProcAddress" and dispatches via function pointers.

This PR proposes an alternative (which is hopefully not that inelegant):
- define two C99 structs of function pointers (one for `Device`, one for `Library`), the "vtables"
- on `loadLibrary` in the init code (a single "getProcAddress") the "vtable" of the backend lib is populated and returned by the implementation
- on `newDevice` the "vtable" is populated and returned by the implementation
- implementations don't need a wrapper, the addresses of the member functions of their C++ objects can directly be used
- example base classes and utility code to populate those vtables (header only) can be provided by the ANARI SDK for convenience for implementers
- implementations will need to catch exceptions themselves and already use the ANARI error mechanisms (status callback), though utility functions and macros can be provided by the SDK

This is only a proof of concept to facilitate discussion, implementing the interface for `Library` (except not implemented `(un-)loadModule`). Implementation for `Device` would be analogous.


