### PR TITLE
anari_cpp updates

### DIFF
--- a/examples/simple/anariTutorial.cpp
+++ b/examples/simple/anariTutorial.cpp
@@ -192,7 +192,7 @@ int main(int argc, const char **argv)
   anari::wait(d, frame);
 
   // access frame and write its content as PNG file
-  const uint32_t *fb = (uint32_t *)anari::map(d, frame, "color");
+  const uint32_t *fb = anari::map<uint32_t>(d, frame, "color");
   stbi_write_png(
       "firstFrame.png", (int)imgSize[0], (int)imgSize[1], 4, fb, 4 * (int)imgSize[0]);
   anari::unmap(d, frame, "color");
@@ -207,7 +207,7 @@ int main(int argc, const char **argv)
     anari::wait(d, frame);
   }
 
-  fb = (uint32_t *)anari::map(d, frame, "color");
+  fb = anari::map<uint32_t>(d, frame, "color");
   stbi_write_png(
       "accumulatedFrame.png", (int)imgSize[0], (int)imgSize[1], 4, fb, 4 * (int)imgSize[0]);
   anari::unmap(d, frame, "color");

--- a/examples/viewer/MainWindow.h
+++ b/examples/viewer/MainWindow.h
@@ -25,14 +25,14 @@ class MainWindow
   MainWindow(const glm::uvec2 &windowSize);
   ~MainWindow();
 
-  void setDevice(ANARIDevice device, const std::string &rendererType);
+  void setDevice(anari::Device device, const std::string &rendererType);
   void setScene(
       std::string sceneName, std::string paramName = "", anari::Any param = {});
 
   void mainLoop();
 
  private:
-  void addObjectToCommit(ANARIObject obj);
+  void addObjectToCommit(anari::Object obj);
 
   void updateCamera();
   void resetCamera();
@@ -47,7 +47,7 @@ class MainWindow
 
   void cleanup();
 
-  friend void frame_show(ANARIDevice, ANARIFrame, MainWindow*);
+  friend void frame_show(anari::Device, anari::Frame, MainWindow*);
 
   static MainWindow *activeWindow;
 
@@ -64,13 +64,13 @@ class MainWindow
   manipulators::Orbit arcball;
 
   // ANARI objects not managed by this class
-  ANARIDevice device{nullptr};
+  anari::Device device{nullptr};
   bool useContinuation = false;
 
   // ANARI objects managed by this class
-  ANARIRenderer renderer{nullptr};
-  ANARICamera camera{nullptr};
-  ANARIFrame frame{nullptr};
+  anari::Renderer renderer{nullptr};
+  anari::Camera camera{nullptr};
+  anari::Frame frame{nullptr};
 
   anari::scenes::SceneHandle scene;
   std::vector<anari::scenes::ParameterInfo> sceneParams;

--- a/libs/anari/include/anari/anari_cpp.hpp
+++ b/libs/anari/include/anari/anari_cpp.hpp
@@ -153,7 +153,8 @@ Array3D newArray3D(Device d,
 
 // Data Updates
 
-void *map(Device, Array);
+template <typename T>
+T *map(Device, Array);
 void unmap(Device, Array);
 
 // Object + Parameter Lifetime Management //

--- a/libs/anari/include/anari/anari_cpp.hpp
+++ b/libs/anari/include/anari/anari_cpp.hpp
@@ -186,7 +186,8 @@ bool getProperty(
 
 // Frame Operations //
 
-const void *map(Device, Frame, const char *channel);
+template <typename T>
+const T *map(Device, Frame, const char *channel);
 void unmap(Device, Frame, const char *channel);
 
 void render(Device, Frame);

--- a/libs/anari/include/anari/anari_cpp.hpp
+++ b/libs/anari/include/anari/anari_cpp.hpp
@@ -63,7 +63,7 @@ using DataType       = ANARIDataType;
 
 Library loadLibrary(const char *name,
     StatusCallback defaultStatus = nullptr,
-    void *defaultStatusPtr = nullptr);
+    const void *defaultStatusPtr = nullptr);
 void unloadLibrary(Library);
 
 void loadModule(Library, const char *name);
@@ -84,15 +84,17 @@ Object newObject(Device d, const char *type, const char *subtype);
 
 template <typename T>
 Array1D newArray1D(Device,
-    T *appMemory,
+    const T *appMemory,
     MemoryDeleter,
-    void *userPtr,
+    const void *userPtr,
     uint64_t numItems1,
     uint64_t byteStride1 = 0);
 
 template <typename T>
-Array1D newArray1D(
-    Device, T *appMemory, uint64_t numItems1 = 1, uint64_t byteStride1 = 0);
+Array1D newArray1D(Device,
+    const T *appMemory,
+    uint64_t numItems1 = 1,
+    uint64_t byteStride1 = 0);
 
 Array1D newArray1D(Device d, ANARIDataType type, uint64_t numItems1);
 
@@ -100,9 +102,9 @@ Array1D newArray1D(Device d, ANARIDataType type, uint64_t numItems1);
 
 template <typename T>
 Array2D newArray2D(Device,
-    T *appMemory,
+    const T *appMemory,
     MemoryDeleter,
-    void *userPtr,
+    const void *userPtr,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t byteStride1 = 0,
@@ -110,7 +112,7 @@ Array2D newArray2D(Device,
 
 template <typename T>
 Array2D newArray2D(Device,
-    T *appMemory,
+    const T *appMemory,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t byteStride1 = 0,
@@ -123,9 +125,9 @@ Array2D newArray2D(
 
 template <typename T>
 Array3D newArray3D(Device,
-    T *appMemory,
+    const T *appMemory,
     MemoryDeleter,
-    void *userPtr,
+    const void *userPtr,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t numItems3,
@@ -135,7 +137,7 @@ Array3D newArray3D(Device,
 
 template <typename T>
 Array3D newArray3D(Device,
-    T *appMemory,
+    const T *appMemory,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t numItems3,

--- a/libs/anari/include/anari/anari_cpp.hpp
+++ b/libs/anari/include/anari/anari_cpp.hpp
@@ -73,10 +73,12 @@ void unloadModule(Library, const char *name);
 
 anari::Device newDevice(Library, const char *name = "default");
 
-template <typename T, typename... Args>
-T newObject(Device, Args...);
-
 Object newObject(Device d, const char *type, const char *subtype);
+
+template <typename T>
+T newObject(Device);
+template <typename T>
+T newObject(Device, const char *subtype);
 
 // Arrays //
 

--- a/libs/anari/include/anari/anari_cpp/anari_cpp_impl.h
+++ b/libs/anari/include/anari/anari_cpp/anari_cpp_impl.h
@@ -30,8 +30,9 @@ inline ANARIDataType getType()
 // Initialization + Introspection /////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-inline Library loadLibrary(
-    const char *name, StatusCallback defaultStatus, void *defaultStatusPtr)
+inline Library loadLibrary(const char *name,
+    StatusCallback defaultStatus,
+    const void *defaultStatusPtr)
 {
   return anariLoadLibrary(name, defaultStatus, defaultStatusPtr);
 }
@@ -172,9 +173,9 @@ inline Renderer newObject<Renderer>(Device d, const char *subtype)
 
 template <typename T>
 inline Array1D newArray1D(Device d,
-    T *appMemory,
+    const T *appMemory,
     MemoryDeleter deleter,
-    void *userPtr,
+    const void *userPtr,
     uint64_t numItems1,
     uint64_t byteStride1)
 {
@@ -189,7 +190,7 @@ inline Array1D newArray1D(Device d,
 
 template <typename T>
 inline Array1D newArray1D(
-    Device d, T *appMemory, uint64_t numItems1, uint64_t byteStride1)
+    Device d, const T *appMemory, uint64_t numItems1, uint64_t byteStride1)
 {
   return anariNewArray1D(d,
       appMemory,
@@ -209,9 +210,9 @@ inline Array1D newArray1D(Device d, ANARIDataType type, uint64_t numItems1)
 
 template <typename T>
 inline Array2D newArray2D(Device d,
-    T *appMemory,
+    const T *appMemory,
     MemoryDeleter deleter,
-    void *userPtr,
+    const void *userPtr,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t byteStride1,
@@ -230,7 +231,7 @@ inline Array2D newArray2D(Device d,
 
 template <typename T>
 inline Array2D newArray2D(Device d,
-    T *appMemory,
+    const T *appMemory,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t byteStride1,
@@ -258,9 +259,9 @@ inline Array2D newArray2D(
 
 template <typename T>
 inline Array3D newArray3D(Device d,
-    T *appMemory,
+    const T *appMemory,
     MemoryDeleter deleter,
-    void *userPtr,
+    const void *userPtr,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t numItems3,
@@ -283,7 +284,7 @@ inline Array3D newArray3D(Device d,
 
 template <typename T>
 inline Array3D newArray3D(Device d,
-    T *appMemory,
+    const T *appMemory,
     uint64_t numItems1,
     uint64_t numItems2,
     uint64_t numItems3,

--- a/libs/anari/include/anari/anari_cpp/anari_cpp_impl.h
+++ b/libs/anari/include/anari/anari_cpp/anari_cpp_impl.h
@@ -411,9 +411,10 @@ inline bool getProperty(
 // Frame Operations ///////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-inline const void *map(Device d, Frame f, const char *channel)
+template <typename T>
+inline const T *map(Device d, Frame f, const char *channel)
 {
-  return anariMapFrame(d, f, channel);
+  return static_cast<const T*>(anariMapFrame(d, f, channel));
 }
 
 inline void unmap(Device d, Frame f, const char *channel)

--- a/libs/anari/include/anari/anari_cpp/anari_cpp_impl.h
+++ b/libs/anari/include/anari/anari_cpp/anari_cpp_impl.h
@@ -317,9 +317,10 @@ inline Array3D newArray3D(Device d,
 
 // Data Updates //
 
-inline void *map(Device d, Array a)
+template <typename T>
+inline T *map(Device d, Array a)
 {
-  return anariMapArray(d, a);
+  return static_cast<T *>(anariMapArray(d, a));
 }
 
 inline void unmap(Device d, Array a)

--- a/tests/render/main.cpp
+++ b/tests/render/main.cpp
@@ -129,7 +129,7 @@ static void renderScene(ANARIDevice d, const std::string &scene)
 
     printf("done!\n");
 
-    auto *pixels = (uint32_t *)anari::map(d, frame, "color");
+    auto *pixels = anari::map<uint32_t>(d, frame, "color");
 
     stbi_write_png(fileName.c_str(),
         (int)g_frameSize.x,


### PR DESCRIPTION
Changes in this PR:
- fixes for the `const` array changes implemented in #42
- template `map<T>(device, array)` over the return type
- template `map<T>(device, frame)` over the return type
- convert the sample viewer to entirely use `anari_cpp`