### PR TITLE
Move initialization of status callbacks to DeviceImpl constructor.

### DIFF
--- a/code_gen/templates/Device.cpp
+++ b/code_gen/templates/Device.cpp
@@ -156,12 +156,13 @@ void $prefixDevice::discardFrame(ANARIFrame handle) {
 // Helper/other functions and data members
 /////////////////////////////////////////////////////////////////////////////
 
-$prefixDevice::$prefixDevice()
-   : refcount(1), deviceObject(this_device(), this_device()),
-   staging(this_device(), this_device()),
-   current(this_device(), this_device())
+$prefixDevice::$prefixDevice(ANARILibrary library)
+   : DeviceImpl(library),
+   refcount(1), deviceObject(this_device(), this_device())
 {
    objects.emplace_back(nullptr); // reserve the null index for the null handle
+   statusCallback = defaultStatusCallback();
+   statusCallbackUserData = defaultStatusCallbackUserPtr();
 }
 $prefixDevice::~$prefixDevice() {
 
@@ -232,10 +233,10 @@ $end_namespaces
 static char deviceName[] = "$libraryname";
 
 extern "C" DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(
-      $libraryname, subtype)
+      $libraryname, libdata, subtype)
 {
    if (subtype == std::string("default") || subtype == std::string("$libraryname"))
-      return (ANARIDevice) new $namespace::$prefixDevice();
+      return (ANARIDevice) new $namespace::$prefixDevice(libdata);
    return nullptr;
 }
 

--- a/code_gen/templates/Device.h
+++ b/code_gen/templates/Device.h
@@ -157,7 +157,7 @@ struct DEVICE_INTERFACE $prefixDevice : public anari::DeviceImpl
    // Helper/other functions and data members
    /////////////////////////////////////////////////////////////////////////////
 
-   $prefixDevice();
+   $prefixDevice(ANARILibrary);
    ~$prefixDevice();
 
    ObjectBase* fromHandle(ANARIObject handle);
@@ -212,9 +212,6 @@ private:
    const void* statusCallbackUserData;
 
    Object<$namespace::Device> deviceObject;
-
-   $namespace::Device staging;
-   $namespace::Device current;
 };
 
 template<class T, class H>

--- a/examples/example_device/ExampleDevice.cpp
+++ b/examples/example_device/ExampleDevice.cpp
@@ -508,6 +508,11 @@ ExampleDevice::ExampleDevice()
   deviceCommit();
 }
 
+ExampleDevice::ExampleDevice(ANARILibrary library) : DeviceImpl(library)
+{
+  deviceCommit();
+}
+
 void ExampleDevice::flushCommitBuffer()
 {
   if (m_needToSortCommits) {
@@ -560,10 +565,10 @@ const void * query_param_info(ANARIDataType type, const char *subtype,
 static char deviceName[] = "example";
 
 extern "C" EXAMPLE_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(
-    example, subtype)
+    example, libdata, subtype)
 {
   if (subtype == std::string("default") || subtype == std::string("example"))
-    return (ANARIDevice) new anari::example_device::ExampleDevice();
+    return (ANARIDevice) new anari::example_device::ExampleDevice(libdata);
   return nullptr;
 }
 

--- a/examples/example_device/ExampleDevice.h
+++ b/examples/example_device/ExampleDevice.h
@@ -131,6 +131,7 @@ struct EXAMPLE_DEVICE_INTERFACE ExampleDevice : public DeviceImpl,
   /////////////////////////////////////////////////////////////////////////////
 
   ExampleDevice();
+  ExampleDevice(ANARILibrary);
   ~ExampleDevice() override = default;
 
   void flushCommitBuffer();

--- a/examples/generated_device_frontend/device/src/TreeDevice.cpp
+++ b/examples/generated_device_frontend/device/src/TreeDevice.cpp
@@ -161,12 +161,15 @@ void TreeDevice::discardFrame(ANARIFrame handle) {
 // Helper/other functions and data members
 /////////////////////////////////////////////////////////////////////////////
 
-TreeDevice::TreeDevice()
-   : refcount(1), deviceObject(this_device(), this_device()),
+TreeDevice::TreeDevice(ANARILibrary library)
+   : DeviceImpl(library),
+   refcount(1), deviceObject(this_device(), this_device()),
    staging(this_device(), this_device()),
    current(this_device(), this_device())
 {
    objects.emplace_back(nullptr); // reserve the null index for the null handle
+   statusCallback = defaultStatusCallback();
+   statusCallbackUserData = defaultStatusCallbackUserPtr();
 }
 TreeDevice::~TreeDevice() {
 
@@ -239,10 +242,10 @@ void anariReportStatus(ANARIDevice handle,
 static char deviceName[] = "tree";
 
 extern "C" DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(
-      tree, subtype)
+      tree, libdata, subtype)
 {
    if (subtype == std::string("default") || subtype == std::string("tree"))
-      return (ANARIDevice) new anari_sdk::tree::TreeDevice();
+      return (ANARIDevice) new anari_sdk::tree::TreeDevice(libdata);
    return nullptr;
 }
 

--- a/examples/generated_device_frontend/device/src/TreeDevice.h
+++ b/examples/generated_device_frontend/device/src/TreeDevice.h
@@ -162,7 +162,7 @@ struct DEVICE_INTERFACE TreeDevice : public anari::DeviceImpl
    // Helper/other functions and data members
    /////////////////////////////////////////////////////////////////////////////
 
-   TreeDevice();
+   TreeDevice(ANARILibrary);
    ~TreeDevice();
 
    ObjectBase* fromHandle(ANARIObject handle);

--- a/libs/anari/API.cpp
+++ b/libs/anari/API.cpp
@@ -128,9 +128,6 @@ extern "C" ANARIDevice anariNewDevice(
   auto _d = lib.newDevice(deviceType);
   if (!_d)
     return nullptr;
-  auto &d = deviceRef(_d);
-  d.m_defaultStatusCB = lib.defaultStatusCB();
-  d.m_defaultStatusCBUserPtr = lib.defaultStatusCBUserPtr();
   return _d;
 }
 ANARI_CATCH_END(nullptr)

--- a/libs/anari/DeviceImpl.cpp
+++ b/libs/anari/DeviceImpl.cpp
@@ -25,6 +25,14 @@ void (*DeviceImpl::getProcAddress(const char *name))(void)
 
 // Device definitions /////////////////////////////////////////////////////////
 
+DeviceImpl::DeviceImpl(ANARILibrary library) :
+  m_defaultStatusCB(((Library *)library)->defaultStatusCB()),
+  m_defaultStatusCBUserPtr(((Library *)library)->defaultStatusCBUserPtr())
+{
+
+}
+
+
 ANARIDevice DeviceImpl::this_device() const
 {
   return (ANARIDevice)this;

--- a/libs/anari/Library.cpp
+++ b/libs/anari/Library.cpp
@@ -272,7 +272,7 @@ void *Library::libraryData() const
 
 ANARIDevice Library::newDevice(const char *subtype) const
 {
-  return m_newDeviceFcn ? m_newDeviceFcn(subtype) : nullptr;
+  return m_newDeviceFcn ? m_newDeviceFcn((ANARILibrary)this, subtype) : nullptr;
 }
 
 const char *Library::defaultDeviceName() const
@@ -293,19 +293,19 @@ const void *Library::defaultStatusCBUserPtr() const
 void Library::loadModule(const char *name) const
 {
   if (m_loadModuleFcn)
-    m_loadModuleFcn(libraryData(), name);
+    m_loadModuleFcn((ANARILibrary)this, name);
 }
 
 void Library::unloadModule(const char *name) const
 {
   if (m_unloadModuleFcn)
-    m_unloadModuleFcn(libraryData(), name);
+    m_unloadModuleFcn((ANARILibrary)this, name);
 }
 
 const char **Library::getDeviceSubtypes()
 {
   if (m_getDeviceSubtypesFcn)
-    return m_getDeviceSubtypesFcn(libraryData());
+    return m_getDeviceSubtypesFcn((ANARILibrary)this);
   return nullptr;
 }
 
@@ -313,7 +313,7 @@ const char **Library::getObjectSubtypes(
     const char *deviceSubtype, ANARIDataType objectType)
 {
   if (m_getObjectSubtypesFcn)
-    return m_getObjectSubtypesFcn(libraryData(), deviceSubtype, objectType);
+    return m_getObjectSubtypesFcn((ANARILibrary)this, deviceSubtype, objectType);
   return nullptr;
 }
 
@@ -323,7 +323,7 @@ const ANARIParameter *Library::getObjectParameters(const char *deviceSubtype,
 {
   if (m_getObjectParametersFcn)
     return m_getObjectParametersFcn(
-        libraryData(), deviceSubtype, objectSubtype, objectType);
+        (ANARILibrary)this, deviceSubtype, objectSubtype, objectType);
   return nullptr;
 }
 
@@ -336,7 +336,7 @@ const void *Library::getParameterProperty(const char *deviceSubtype,
     ANARIDataType propertyType)
 {
   if (m_getObjectParameterPropertyFcn)
-    return m_getObjectParameterPropertyFcn(libraryData(),
+    return m_getObjectParameterPropertyFcn((ANARILibrary)this,
         deviceSubtype,
         objectSubtype,
         objectType,

--- a/libs/anari/include/anari/backend/DeviceImpl.h
+++ b/libs/anari/include/anari/backend/DeviceImpl.h
@@ -6,6 +6,9 @@
 // anari
 #include "anari/anari.h"
 #include "anari/anari_cpp/Traits.h"
+
+#include "anari/backend/Library.h"
+
 // std
 #include <map>
 #include <string>
@@ -150,22 +153,20 @@ struct ANARI_INTERFACE DeviceImpl
   // Helper/other functions and data members
   /////////////////////////////////////////////////////////////////////////////
 
+  DeviceImpl(ANARILibrary);
   DeviceImpl() = default;
   virtual ~DeviceImpl() = default;
 
   ANARIDevice this_device() const;
+
+  ANARIStatusCallback m_defaultStatusCB{nullptr};
+  const void *m_defaultStatusCBUserPtr{nullptr};
 
  protected:
   ANARIStatusCallback defaultStatusCallback() const;
   const void *defaultStatusCallbackUserPtr() const;
 
   bool handleIsDevice(ANARIObject obj) const;
-
- public:
-  // NOTE: Unsuccessful to get the declaration of anariNewDevice() declared
-  // correctly as a friend function to keep these private.
-  ANARIStatusCallback m_defaultStatusCB{nullptr};
-  const void *m_defaultStatusCBUserPtr{nullptr};
 };
 
 ANARI_TYPEFOR_SPECIALIZATION(DeviceImpl *, ANARI_DEVICE);

--- a/libs/anari/include/anari/backend/Library.h
+++ b/libs/anari/include/anari/backend/Library.h
@@ -54,31 +54,31 @@ struct ANARI_INTERFACE Library
   ANARIStatusCallback m_defaultStatusCB{nullptr};
   const void *m_defaultStatusCBUserPtr{nullptr};
 
-  using NewDeviceFcn = ANARIDevice (*)(const char *);
+  using NewDeviceFcn = ANARIDevice (*)(ANARILibrary, const char *);
   NewDeviceFcn m_newDeviceFcn{nullptr};
 
   using FreeFcn = void (*)(void *);
   FreeFcn m_freeFcn{nullptr};
 
-  using ModuleFcn = void (*)(void *, const char *);
+  using ModuleFcn = void (*)(ANARILibrary, const char *);
   ModuleFcn m_loadModuleFcn{nullptr};
   ModuleFcn m_unloadModuleFcn{nullptr};
 
-  using GetDeviceSubtypesFcn = const char **(*)(void *);
+  using GetDeviceSubtypesFcn = const char **(*)(ANARILibrary);
   GetDeviceSubtypesFcn m_getDeviceSubtypesFcn{nullptr};
 
-  using GetObjectSubtypesFcn = const char **(*)(void *,
+  using GetObjectSubtypesFcn = const char **(*)(ANARILibrary,
       const char *,
       ANARIDataType);
   GetObjectSubtypesFcn m_getObjectSubtypesFcn{nullptr};
 
-  using GetObjectParametersFcn = const ANARIParameter *(*)(void *,
+  using GetObjectParametersFcn = const ANARIParameter *(*)(ANARILibrary,
       const char *,
       const char *,
       ANARIDataType);
   GetObjectParametersFcn m_getObjectParametersFcn{nullptr};
 
-  using GetObjectParameterPropertyFcn = const char **(*)(void *,
+  using GetObjectParameterPropertyFcn = const char **(*)(ANARILibrary,
       const char *,
       const char *,
       ANARIDataType,
@@ -90,8 +90,9 @@ struct ANARI_INTERFACE Library
 };
 
 // [REQUIRED] Define the function which allocates Device objects by subtype
-#define ANARI_DEFINE_LIBRARY_NEW_DEVICE(libname, type)                         \
-  ANARIDevice anari_library_##libname##_new_device(const char *type)
+#define ANARI_DEFINE_LIBRARY_NEW_DEVICE(libname, libdata, type)                \
+  ANARIDevice anari_library_##libname##_new_device(ANARILibrary libdata,       \
+    const char *type)
 
 // [OPTIONAL] Define the initialization function when library is loaded.
 #define ANARI_DEFINE_LIBRARY_INIT(libname) void anari_library_##libname##_init()
@@ -104,28 +105,30 @@ struct ANARI_INTERFACE Library
 // [OPTIONAL] Define the function which frees library-specific storage on
 //            destruction.
 #define ANARI_DEFINE_LIBRARY_FREE(libname, libdata)                            \
-  void anari_library_##libname##_free(void *libdata)
+  void anari_library_##libname##_free(ANARILibrary libdata)
 
 // [OPTIONAL] Define the function which loads a library-specific module.
 #define ANARI_DEFINE_LIBRARY_LOAD_MODULE(libname, libdata, modname)            \
-  void anari_library_##libname##_load_module(void *libdata, const char *modname)
+  void anari_library_##libname##_load_module(ANARILibrary libdata,             \
+    const char *modname)
 
 // [OPTIONAL] Define the function which unloads a library-specific module.
 #define ANARI_DEFINE_LIBRARY_UNLOAD_MODULE(libname, libdata, modname)          \
   void anari_library_##libname##_unload_module(                                \
-      void *libdata, const char *modname)
+      ANARILibrary libdata, const char *modname)
 
 // [OPTIONAL] Define introspection functions.
 #define ANARI_DEFINE_LIBRARY_GET_DEVICE_SUBTYPES(libname, libdata)             \
-  const char **anari_library_##libname##_get_device_subtypes(void *libdata)
+  const char **anari_library_##libname##_get_device_subtypes(                  \
+    ANARILibrary libdata)
 #define ANARI_DEFINE_LIBRARY_GET_OBJECT_SUBTYPES(                              \
     libname, libdata, deviceSubtype, objectType)                               \
   const char **anari_library_##libname##_get_object_subtypes(                  \
-      void *libdata, const char *deviceSubtype, ANARIDataType objectType)
+      ANARILibrary libdata, const char *deviceSubtype, ANARIDataType objectType)
 #define ANARI_DEFINE_LIBRARY_GET_OBJECT_PARAMETERS(                            \
     libname, libdata, deviceSubtype, objectSubtype, objectType)                \
   const ANARIParameter *anari_library_##libname##_get_object_parameters(       \
-      void *libdata,                                                           \
+      ANARILibrary libdata,                                                    \
       const char *deviceSubtype,                                               \
       const char *objectSubtype,                                               \
       ANARIDataType objectType)
@@ -138,7 +141,8 @@ struct ANARI_INTERFACE Library
     parameterType,                                                             \
     propertyName,                                                              \
     propertyType)                                                              \
-  const void *anari_library_##libname##_get_parameter_property(void *libdata,  \
+  const void *anari_library_##libname##_get_parameter_property(                \
+      ANARILibrary libdata,                                                    \
       const char *deviceSubtype,                                               \
       const char *objectSubtype,                                               \
       ANARIDataType objectType,                                                \

--- a/libs/debug_device/DebugDevice.cpp
+++ b/libs/debug_device/DebugDevice.cpp
@@ -819,8 +819,9 @@ void DebugDevice::deviceCommit()
   }
 }
 
-DebugDevice::DebugDevice()
-    : wrapped(nullptr),
+DebugDevice::DebugDevice(ANARILibrary library)
+    : DeviceImpl(library),
+      wrapped(nullptr),
       staged(nullptr),
       deviceInfo{this, this_device(), this_device()},
       debugObjectFactory(nullptr)
@@ -942,10 +943,10 @@ void DebugDevice::reportObjectUse(ANARIDataType objtype, const char *objsubtype)
 static char deviceName[] = "debug";
 
 extern "C" DEBUG_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(
-    debug, subtype)
+    debug, libdata, subtype)
 {
   if (subtype == std::string("default") || subtype == std::string("debug"))
-    return (ANARIDevice) new anari::debug_device::DebugDevice();
+    return (ANARIDevice) new anari::debug_device::DebugDevice(libdata);
   return nullptr;
 }
 

--- a/libs/debug_device/DebugDevice.h
+++ b/libs/debug_device/DebugDevice.h
@@ -157,7 +157,7 @@ struct DEBUG_DEVICE_INTERFACE DebugDevice : public DeviceImpl, public RefCounted
   void deviceUnsetParameter(const char *id);
   void deviceCommit();
 
-  DebugDevice();
+  DebugDevice(ANARILibrary);
   ~DebugDevice();
 
   ANARIObject newObjectHandle(ANARIObject, ANARIDataType);

--- a/libs/sink_device/SinkDevice.cpp
+++ b/libs/sink_device/SinkDevice.cpp
@@ -285,7 +285,7 @@ void SinkDevice::discardFrame(ANARIFrame) {}
 
 // Other SinkDevice definitions ////////////////////////////////////////////
 
-SinkDevice::SinkDevice()
+SinkDevice::SinkDevice(ANARILibrary library) : DeviceImpl(library)
 {
   nextHandle<ANARIObject>(); // insert a handle at 0
 }
@@ -301,10 +301,10 @@ const void * query_param_info(ANARIDataType type, const char *subtype,
 
 static char deviceName[] = "sink";
 
-extern "C" SINK_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(sink, subtype)
+extern "C" SINK_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(sink, libdata, subtype)
 {
   if (subtype == std::string("default") || subtype == std::string("sink"))
-    return (ANARIDevice) new anari::sink_device::SinkDevice();
+    return (ANARIDevice) new anari::sink_device::SinkDevice(libdata);
   return nullptr;
 }
 

--- a/libs/sink_device/SinkDevice.h
+++ b/libs/sink_device/SinkDevice.h
@@ -136,7 +136,7 @@ struct SINK_DEVICE_INTERFACE SinkDevice : public DeviceImpl, public RefCounted
   // Helper/other functions and data members
   /////////////////////////////////////////////////////////////////////////////
 
-  SinkDevice();
+  SinkDevice(ANARILibrary);
   ~SinkDevice() = default;
 
  private:


### PR DESCRIPTION
* DeviceImpl constructor takes `ANARILibrary` argument
* The C library interface functions also take `ANARILibrary` instead of `void *libdata`