### PR TITLE
Fix VS2017 build errors in struct initialization

### DIFF
--- a/examples/example_device/scene/bvh/SweepSAHBuilder.h
+++ b/examples/example_device/scene/bvh/SweepSAHBuilder.h
@@ -304,10 +304,8 @@ SweepSAHBuildTask::build(const SAHTaskWorkItem &item)
 
   left.setBounds(left_bbox);
   right.setBounds(right_bbox);
-  SAHTaskWorkItem firstItem(
-      {first_child + 0, item.begin, split_index, item.depth + 1});
-  SAHTaskWorkItem second_item(
-      {first_child + 1, split_index, item.end, item.depth + 1});
+  SAHTaskWorkItem firstItem = {first_child + 0, item.begin, split_index, item.depth + 1};
+  SAHTaskWorkItem second_item = {first_child + 1, split_index, item.end, item.depth + 1};
   return std::make_optional(std::make_pair(firstItem, second_item));
 }
 


### PR DESCRIPTION
When build on VS2017, the following error triggers:

> Severity	Code	Description	Project	File	Line	Suppression State
Error	C2100	illegal indirection	anari_library_example	d:\opensource\anari-sdk\examples\example_device\scene\bvh\SweepSAHBuilder.h	308	

The error is a bit vague and did not give the correct fail reason in fact. Since `SAHTaskWorkItem` is a struct and no constructor provided, a common used initialization method of struct is provided. After the fix, the project build successfully on VS2017.