### PR TITLE
fix api error handling

### DIFF
--- a/examples/example_device/ExampleDevice.cpp
+++ b/examples/example_device/ExampleDevice.cpp
@@ -363,13 +363,6 @@ void ExampleDevice::setParameter(
 
   if (fcn)
     fcn(object, name, mem);
-  else {
-    fprintf(stderr,
-        "warning - no parameter setter for type '%s'"
-        ", '%s' parameter will be ignored\n",
-        toString(type),
-        name);
-  }
 }
 
 void ExampleDevice::unsetParameter(ANARIObject o, const char *name)
@@ -567,11 +560,6 @@ extern "C" EXAMPLE_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(
   if (subtype == std::string("default") || subtype == std::string("example"))
     return (ANARIDevice) new anari::example_device::ExampleDevice(library);
   return nullptr;
-}
-
-extern "C" EXAMPLE_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_INIT(example)
-{
-  printf("...loaded example library!\n");
 }
 
 extern "C" EXAMPLE_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_GET_DEVICE_SUBTYPES(

--- a/libs/sink_device/SinkDevice.cpp
+++ b/libs/sink_device/SinkDevice.cpp
@@ -309,9 +309,7 @@ static char deviceName[] = "sink";
 extern "C" SINK_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_NEW_DEVICE(
     sink, library, subtype)
 {
-  if (subtype == std::string("default") || subtype == std::string("sink"))
-    return (ANARIDevice) new anari::sink_device::SinkDevice(library);
-  return nullptr;
+  return (ANARIDevice) new anari::sink_device::SinkDevice(library);
 }
 
 extern "C" SINK_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_INIT(sink) {}


### PR DESCRIPTION
This PR removes the termination behavior from loading from the `environment` library without having `ANARI_LIBRARY` set and removes `printf()` calls in the example device.

Additionally, the `sink` library will now robustly accept any device type string and always construct the `default` sink device as this is in line with the goal of the `sink` device's design.