### PR TITLE
Fix strncmp length typo

### DIFF
--- a/code_gen/templates/FrameObject.cpp
+++ b/code_gen/templates/FrameObject.cpp
@@ -38,10 +38,10 @@ void *Object<Frame>::mapFrame(const char *channel,
 {
   *width = size[0];
   *height = size[1];
-  if (std::strncmp(channel, "channel.color", 5) == 0) {
+  if (std::strncmp(channel, "channel.color", 13) == 0) {
     *pixelType = colorType;
     return color.data();
-  } else if (std::strncmp(channel, "channel.depth", 5) == 0) {
+  } else if (std::strncmp(channel, "channel.depth", 13) == 0) {
     *pixelType = depthType;
     return depth.data();
   } else {

--- a/examples/generated_device_frontend/device/src/TreeFrameObject.cpp
+++ b/examples/generated_device_frontend/device/src/TreeFrameObject.cpp
@@ -45,10 +45,10 @@ void *Object<Frame>::mapFrame(const char *channel,
 {
   *width = size[0];
   *height = size[1];
-  if (std::strncmp(channel, "channel.color", 5) == 0) {
+  if (std::strncmp(channel, "channel.color", 13) == 0) {
     *pixelType = colorType;
     return color.data();
-  } else if (std::strncmp(channel, "channel.depth", 5) == 0) {
+  } else if (std::strncmp(channel, "channel.depth", 13) == 0) {
     *pixelType = depthType;
     return depth.data();
   } else {

--- a/examples/trace/trace_wrapper.c
+++ b/examples/trace/trace_wrapper.c
@@ -61,7 +61,7 @@ void image(const char *channel, const void *pixels, int width, int height, ANARI
     count += 1;
     char filename[100];
     snprintf(filename, sizeof(filename), "%s%d.png", channel, count);
-    if(strncmp(channel, "channel.color",5) == 0) {
+    if(strncmp(channel, "channel.color", 13) == 0) {
         stbi_flip_vertically_on_write(1);
         stbi_write_png(filename, width, height, 4, pixels, 4*width);
     }


### PR DESCRIPTION
[Recently](https://github.com/KhronosGroup/ANARI-SDK/commit/7f4c0ca2738bf5006dcfea91d4d14cc45de1d579), the API for `Frame`s was changed to require the `channel.` prefix. However, the `strncmp` calls that used to exist weren't updated for the new length. This PR fixes that typo.