### PR TITLE
Adding environment variables for remote device's server.hostname and server.port

### DIFF
--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -4,6 +4,8 @@
 #include "Device.h"
 #include <anari/backend/LibraryImpl.h>
 #include <anari/anari_cpp.hpp>
+#include <climits>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -564,6 +566,26 @@ void Device::discardFrame(ANARIFrame) {}
 Device::Device(std::string subtype) : manager(async::make_connection_manager())
 {
   logging::Initialize();
+
+  char *serverHostName = getenv("ANARI_REMOTE_SERVER_HOSTNAME");
+  if (serverHostName) {
+    server.hostname = std::string(serverHostName);
+    LOG(logging::Level::Info) << "Server hostname specified via environment: "
+      << server.hostname;
+  }
+
+  char *serverPort = getenv("ANARI_REMOTE_SERVER_PORT");
+  if (serverPort) {
+    int p = std::stoi(serverPort);
+    if (p >= 0 && p <= USHRT_MAX) {
+      server.port = (unsigned short)p;
+      LOG(logging::Level::Info) << "Server port specified via environment: "
+        << server.port;
+    } else {
+      LOG(logging::Level::Warning)
+        << "Server port specified via environment but ill-formed: " << p;
+    }
+  }
 
   remoteSubtype = subtype;
 }

--- a/libs/remote_device/README.md
+++ b/libs/remote_device/README.md
@@ -43,6 +43,15 @@ i.e., before any other parameters are set, committed, before device properties
 are queried, etc. In order to reset the hostname and port over which to connect
 to the server, a new remote device instance must be created.
 
+Default values for the server's hostname and port can be set on the client via
+environment variables. The device parameters have precedence over these default
+values though:
+
+```
+ANARI_REMOTE_SERVER_HOSTNAME="localhost"
+ANARI_REMOTE_SERVER_PORT=31050
+```
+
 Currently, the server accepts a single connection at a time.
 
 ### Debugging


### PR DESCRIPTION
ANARI_REMOTE_SERVER_HOSTNAME="localhost"
ANARI_REMOTE_SERVER_PORT=31050

Those environment variables allow the user to set defaults on the client side. (If the app specifies device params "server.hostname" and "server.port", these take precedence over the environment variables.)