### PR TITLE
Implement mapParameterArrayN() functions

### DIFF
--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -178,7 +178,6 @@ void Device::unmapArray(ANARIArray array)
   buf->write((const char *)&remoteDevice, sizeof(remoteDevice));
   buf->write((const char *)&array, sizeof(array));
   uint64_t numBytes = arrays[array].size();
-  buf->write((const char *)&numBytes, sizeof(numBytes));
   buf->write(arrays[array].data(), numBytes);
   write(MessageType::UnmapArray, buf);
 

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -47,8 +47,12 @@ void *Device::mapParameterArray1D(ANARIObject o,
     uint64_t numElements1,
     uint64_t *elementStride)
 {
-  LOG(logging::Level::Warning) << "Array parameter mapping not implemented";
-  return nullptr;
+  auto array = newArray1D(nullptr, nullptr, nullptr, dataType, numElements1);
+  ParameterArray pa{o, name};
+  parameterArrays[pa] = array;
+  setParameter(o, name, ANARI_ARRAY1D, &array);
+  *elementStride = anari::sizeOf(dataType);
+  return mapArray(array);
 }
 
 void *Device::mapParameterArray2D(ANARIObject o,
@@ -58,8 +62,13 @@ void *Device::mapParameterArray2D(ANARIObject o,
     uint64_t numElements2,
     uint64_t *elementStride)
 {
-  LOG(logging::Level::Warning) << "Array parameter mapping not implemented";
-  return nullptr;
+  auto array = newArray2D(
+      nullptr, nullptr, nullptr, dataType, numElements1, numElements2);
+  ParameterArray pa{o, name};
+  parameterArrays[pa] = array;
+  setParameter(o, name, ANARI_ARRAY2D, &array);
+  *elementStride = anari::sizeOf(dataType);
+  return mapArray(array);
 }
 
 void *Device::mapParameterArray3D(ANARIObject o,
@@ -70,13 +79,29 @@ void *Device::mapParameterArray3D(ANARIObject o,
     uint64_t numElements3,
     uint64_t *elementStride)
 {
-  LOG(logging::Level::Warning) << "Array parameter mapping not implemented";
-  return nullptr;
+  auto array = newArray3D(nullptr,
+      nullptr,
+      nullptr,
+      dataType,
+      numElements1,
+      numElements2,
+      numElements3);
+  ParameterArray pa{o, name};
+  parameterArrays[pa] = array;
+  setParameter(o, name, ANARI_ARRAY3D, &array);
+  *elementStride = anari::sizeOf(dataType);
+  return mapArray(array);
 }
 
 void Device::unmapParameterArray(ANARIObject o, const char *name)
 {
-  // no-op
+  ParameterArray pa{o, name};
+  auto it = parameterArrays.find(pa);
+  if (it != parameterArrays.end()) {
+    ANARIArray array = it->second;
+    unmapArray(array);
+    parameterArrays.erase(pa);
+  }
 }
 
 ANARIArray1D Device::newArray1D(const void *appMemory,

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -240,6 +240,20 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   std::map<ANARIObject, Frame> frames;
   std::map<ANARIArray, std::vector<char>> arrays;
 
+  // Need to keep track of these to implement
+  // (un)mapParameterArray correctly
+  struct ParameterArray
+  {
+    ANARIObject object{nullptr};
+    const char *name = "";
+    bool operator<(const ParameterArray &other) const {
+      return object && object == other.object
+        && strlen(name) > 0
+        && std::string(name) < std::string(other.name);
+      }
+  };
+  std::map<ParameterArray, ANARIArray> parameterArrays;
+
   ANARIObject registerNewObject(ANARIDataType type, std::string subtype = "");
   ANARIArray registerNewArray(ANARIDataType type,
       const void *appMemory,


### PR DESCRIPTION
Also fixes an issue where content received upon `unmapArray` was interpreted as POD and not properly translated on the server, e.g., in case the array contained objects.