### PR TITLE
Allow writing zero-length array through remote pass-through device

### DIFF
--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -255,7 +255,12 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   std::vector<ObjectSubtypes> objectSubtypes;
 
   std::map<ANARIObject, Frame> frames;
-  std::map<ANARIArray, std::vector<char>> arrays;
+  struct ArrayData
+  {
+    ssize_t bytesExpected{-1};
+    std::vector<char> value;
+  };
+  std::map<ANARIArray, ArrayData> arrays;
 
   // Need to keep track of these to implement
   // (un)mapParameterArray correctly


### PR DESCRIPTION
This is a tiny fix for the case that arrays are mapped/unmapped, triggering a zero-bytes write message. Before, this would hang because of a `condition_variable` waiting for any bytes written to the socket before releasing its lock.