### PR TITLE
Cleanup and smaller fixes to the remote device

### DIFF
--- a/libs/remote_device/ArrayInfo.h
+++ b/libs/remote_device/ArrayInfo.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <anari/anari.h>
-#include "Buffer.h"
 
 namespace remote {
 

--- a/libs/remote_device/Buffer.cpp
+++ b/libs/remote_device/Buffer.cpp
@@ -5,6 +5,12 @@
 
 namespace remote {
 
+Buffer::Buffer(const char *ptr, size_t numBytes)
+{
+  write(ptr, numBytes);
+  seek(0);
+}
+
 // read overload for std::string
 bool Buffer::read(std::string &val)
 {

--- a/libs/remote_device/Buffer.cpp
+++ b/libs/remote_device/Buffer.cpp
@@ -82,6 +82,43 @@ bool Buffer::write(const StringList &val)
   return true;
 }
 
+// read overload for parameter lists
+bool Buffer::read(ParameterList &val)
+{
+  uint64_t size = 0;
+  if (!read(size))
+    return false;
+
+  for (size_t i = 0; i < size; ++i) {
+    std::string name;
+    read(name);
+
+    ANARIDataType type;
+    read(type);
+
+    val.push_back(name, type);
+  }
+
+  return true;
+}
+
+// write overload for parameter lists
+bool Buffer::write(const ParameterList &val)
+{
+  if (!write(uint64_t(val.size())))
+    return false;
+
+  const Parameter *params = val.data();
+  for (size_t i = 0; i < val.size(); ++i) {
+    std::string name;
+    if (params[i].name != nullptr)
+      name = std::string(params[i].name);
+    write(name);
+    write(params[i].type);
+  }
+
+  return true;
+}
 // low-level write function
 size_t Buffer::write(const char *ptr, size_t numBytes)
 {

--- a/libs/remote_device/Buffer.cpp
+++ b/libs/remote_device/Buffer.cpp
@@ -1,0 +1,76 @@
+// Copyright 2023 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Buffer.h"
+
+namespace remote {
+
+// read overload for std::string
+bool Buffer::read(std::string &val)
+{
+  uint64_t strLen = 0;
+  read((char *)&strLen, sizeof(strLen));
+  std::vector<char> bytesToString(strLen);
+  size_t res = read(bytesToString.data(), bytesToString.size());
+  if (res == strLen) {
+    val = std::string(bytesToString.data(), bytesToString.size());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// write overload for std::string
+bool Buffer::write(const std::string &val)
+{
+  uint64_t strLen = val.size();
+  if (!write(strLen))
+    return false;
+  size_t res = write(val.data(), val.size());
+  return res == strLen;
+}
+
+// low-level read function
+size_t Buffer::read(char *ptr, size_t numBytes)
+{
+  if (pos + numBytes > size())
+    return 0;
+
+  memcpy(ptr, data() + pos, numBytes);
+
+  pos += numBytes;
+
+  return numBytes;
+}
+
+// low-level write function
+size_t Buffer::write(const char *ptr, size_t numBytes)
+{
+  if (pos + numBytes >= size()) {
+    try {
+      resize(pos + numBytes);
+    } catch (...) {
+      return 0;
+    }
+  }
+
+  memcpy(data() + pos, ptr, numBytes);
+
+  pos += numBytes;
+
+  return numBytes;
+}
+
+// check if we moved past the end
+bool Buffer::eof() const
+{
+  return pos == size();
+}
+
+// jump to position
+void Buffer::seek(size_t p)
+{
+  pos = p;
+}
+
+} // namespace remote

--- a/libs/remote_device/Buffer.cpp
+++ b/libs/remote_device/Buffer.cpp
@@ -49,6 +49,39 @@ size_t Buffer::read(char *ptr, size_t numBytes)
   return numBytes;
 }
 
+// read overload for string lists
+bool Buffer::read(StringList &val)
+{
+  uint64_t size = 0;
+  if (!read(size))
+    return false;
+
+  for (size_t i = 0; i < size; ++i) {
+    std::string str;
+    read(str);
+    val.push_back(str);
+  }
+
+  return true;
+}
+
+// write overload for string lists
+bool Buffer::write(const StringList &val)
+{
+  if (!write(uint64_t(val.size())))
+    return false;
+
+  const char **strings = val.data();
+  for (size_t i = 0; i < val.size(); ++i) {
+    std::string str;
+    if (strings[i] != nullptr)
+      str = std::string(strings[i]);
+    write(str);
+  }
+
+  return true;
+}
+
 // low-level write function
 size_t Buffer::write(const char *ptr, size_t numBytes)
 {

--- a/libs/remote_device/Buffer.h
+++ b/libs/remote_device/Buffer.h
@@ -9,6 +9,8 @@
 #include <vector>
 // anari
 #include <anari/anari.h>
+// ours
+#include "StringList.h"
 
 namespace remote {
 
@@ -43,6 +45,12 @@ struct Buffer : std::vector<char>
 
   // write overload for std::string
   bool write(const std::string &val);
+
+  // read overload for string lists
+  bool read(StringList &val);
+
+  // write overload for string lists
+  bool write(const StringList &val);
 
   // low-level read function
   size_t read(char *ptr, size_t numBytes);

--- a/libs/remote_device/Buffer.h
+++ b/libs/remote_device/Buffer.h
@@ -30,73 +30,23 @@ struct Buffer : std::vector<char>
     return res == sizeof(val);
   }
 
-  // read std::string
-  bool read(std::string &val)
-  {
-    uint64_t strLen = 0;
-    read((char *)&strLen, sizeof(strLen));
-    std::vector<char> bytesToString(strLen);
-    size_t res = read(bytesToString.data(), bytesToString.size());
-    if (res == strLen) {
-      val = std::string(bytesToString.data(), bytesToString.size());
-      return true;
-    } else {
-      return false;
-    }
-  }
+  // read overload for std::string
+  bool read(std::string &val);
 
-  // write std::string
-  bool write(const std::string &val)
-  {
-    uint64_t strLen = val.size();
-    if (!write(strLen))
-      return false;
-    size_t res = write(val.data(), val.size());
-    return res == strLen;
-  }
+  // write overload for std::string
+  bool write(const std::string &val);
 
   // low-level read function
-  size_t read(char *ptr, size_t numBytes)
-  {
-    if (pos + numBytes > size())
-      return 0;
-
-    memcpy(ptr, data() + pos, numBytes);
-
-    pos += numBytes;
-
-    return numBytes;
-  }
+  size_t read(char *ptr, size_t numBytes);
 
   // low-level read function
-  size_t write(const char *ptr, size_t numBytes)
-  {
-    if (pos + numBytes >= size()) {
-      try {
-        resize(pos + numBytes);
-      } catch (...) {
-        return 0;
-      }
-    }
-
-    memcpy(data() + pos, ptr, numBytes);
-
-    pos += numBytes;
-
-    return numBytes;
-  }
+  size_t write(const char *ptr, size_t numBytes);
 
   // check if we moved past the end
-  bool eof() const
-  {
-    return pos == size();
-  }
+  bool eof() const;
 
   // jump to position
-  void seek(size_t p)
-  {
-    pos = p;
-  }
+  void seek(size_t p);
 
   size_t pos = 0;
 };

--- a/libs/remote_device/Buffer.h
+++ b/libs/remote_device/Buffer.h
@@ -14,6 +14,14 @@ namespace remote {
 
 struct Buffer : std::vector<char>
 {
+  // Create empty buffer
+  Buffer() = default;
+
+  // Fill buffer with data and set position to zero
+  // This is equivalent to creating an empty buffer
+  // and then calling: write(ptr, numBytes); seek(0);
+  Buffer(const char *ptr, size_t numBytes);
+
   // trivial or POD layout read function
   template <typename T>
   bool read(T &val)

--- a/libs/remote_device/Buffer.h
+++ b/libs/remote_device/Buffer.h
@@ -10,6 +10,7 @@
 // anari
 #include <anari/anari.h>
 // ours
+#include "ParameterList.h"
 #include "StringList.h"
 
 namespace remote {
@@ -51,6 +52,12 @@ struct Buffer : std::vector<char>
 
   // write overload for string lists
   bool write(const StringList &val);
+
+  // read overload for parameter lists
+  bool read(ParameterList &val);
+
+  // write overload for parameter lists
+  bool write(const ParameterList &val);
 
   // low-level read function
   size_t read(char *ptr, size_t numBytes);

--- a/libs/remote_device/CMakeLists.txt
+++ b/libs/remote_device/CMakeLists.txt
@@ -36,6 +36,7 @@ project_sources(PRIVATE
   async/connection_manager.cpp
   async/message.cpp
   ArrayInfo.cpp
+  Buffer.cpp
   Compression.cpp
   Device.cpp
   Frame.cpp
@@ -76,6 +77,7 @@ PRIVATE
   async/connection_manager.cpp
   async/message.cpp
   ArrayInfo.cpp
+  Buffer.cpp
   Compression.cpp
   Logging.cpp
   Server.cpp

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -974,9 +974,7 @@ void Device::handleMessage(async::connection::reason reason,
     } else if (message->type() == MessageType::Property) {
       std::unique_lock l(syncProperties.mtx);
 
-      Buffer buf;
-      buf.write(message->data(), message->size());
-      buf.seek(0);
+      Buffer buf(message->data(), message->size());
 
       buf.read(property.object);
       buf.read(property.name);
@@ -1031,9 +1029,7 @@ void Device::handleMessage(async::connection::reason reason,
     } else if (message->type() == MessageType::ObjectSubtypes) {
       std::unique_lock l(syncObjectSubtypes.mtx);
 
-      Buffer buf;
-      buf.write(message->data(), message->size());
-      buf.seek(0);
+      Buffer buf(message->data(), message->size());
 
       ObjectSubtypes os;
 
@@ -1057,9 +1053,7 @@ void Device::handleMessage(async::connection::reason reason,
     } else if (message->type() == MessageType::ObjectInfo) {
       std::unique_lock l(syncObjectInfo.mtx);
 
-      Buffer buf;
-      buf.write(message->data(), message->size());
-      buf.seek(0);
+      Buffer buf(message->data(), message->size());
 
       ObjectInfo oi;
 
@@ -1107,9 +1101,7 @@ void Device::handleMessage(async::connection::reason reason,
     } else if (message->type() == MessageType::ParameterInfo) {
       std::unique_lock l(syncParameterInfo.mtx);
 
-      Buffer buf;
-      buf.write(message->data(), message->size());
-      buf.seek(0);
+      Buffer buf(message->data(), message->size());
 
       ParameterInfo pi;
 

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -1020,15 +1020,18 @@ void Device::handleMessage(async::connection::reason reason,
       buf.read(oi->info.name);
       buf.read(oi->info.type);
       if (oi->info.type == ANARI_STRING) {
-        buf.read(oi->info.asString);
+        std::string str;
+        buf.read(str);
+        oi->info.asAny = helium::AnariAny(oi->info.type, str.c_str());
       } else if (oi->info.type == ANARI_STRING_LIST) {
         buf.read(oi->info.asStringList);
       } else if (oi->info.type == ANARI_PARAMETER_LIST) {
         buf.read(oi->info.asParameterList);
       } else {
         if (!buf.eof()) {
-          oi->info.asOther.resize(anari::sizeOf(oi->info.type));
-          buf.read(oi->info.asOther.data(), anari::sizeOf(oi->info.type));
+          std::vector<char> bytes(anari::sizeOf(oi->info.type));
+          buf.read(bytes.data(), bytes.size());
+          oi->info.asAny = helium::AnariAny(oi->info.type, bytes.data());
         }
       }
 
@@ -1050,15 +1053,18 @@ void Device::handleMessage(async::connection::reason reason,
       buf.read(pi->info.name);
       buf.read(pi->info.type);
       if (pi->info.type == ANARI_STRING) {
-        buf.read(pi->info.asString);
+        std::string str;
+        buf.read(str);
+        pi->info.asAny = helium::AnariAny(pi->info.type, str.c_str());
       } else if (pi->info.type == ANARI_STRING_LIST) {
         buf.read(pi->info.asStringList);
       } else if (pi->info.type == ANARI_PARAMETER_LIST) {
         buf.read(pi->info.asParameterList);
       } else {
         if (!buf.eof()) {
-          pi->info.asOther.resize(anari::sizeOf(pi->info.type));
-          buf.read(pi->info.asOther.data(), anari::sizeOf(pi->info.type));
+          std::vector<char> bytes(anari::sizeOf(pi->info.type));
+          buf.read(bytes.data(), bytes.size());
+          pi->info.asAny = helium::AnariAny(pi->info.type, bytes.data());
         }
       }
 

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -1022,16 +1022,16 @@ void Device::handleMessage(async::connection::reason reason,
       if (oi->info.type == ANARI_STRING) {
         std::string str;
         buf.read(str);
-        oi->info.asAny = helium::AnariAny(oi->info.type, str.c_str());
+        oi->info.value.asAny = helium::AnariAny(oi->info.type, str.c_str());
       } else if (oi->info.type == ANARI_STRING_LIST) {
-        buf.read(oi->info.asStringList);
+        buf.read(oi->info.value.asStringList);
       } else if (oi->info.type == ANARI_PARAMETER_LIST) {
-        buf.read(oi->info.asParameterList);
+        buf.read(oi->info.value.asParameterList);
       } else {
         if (!buf.eof()) {
           std::vector<char> bytes(anari::sizeOf(oi->info.type));
           buf.read(bytes.data(), bytes.size());
-          oi->info.asAny = helium::AnariAny(oi->info.type, bytes.data());
+          oi->info.value.asAny = helium::AnariAny(oi->info.type, bytes.data());
         }
       }
 
@@ -1055,16 +1055,16 @@ void Device::handleMessage(async::connection::reason reason,
       if (pi->info.type == ANARI_STRING) {
         std::string str;
         buf.read(str);
-        pi->info.asAny = helium::AnariAny(pi->info.type, str.c_str());
+        pi->info.value.asAny = helium::AnariAny(pi->info.type, str.c_str());
       } else if (pi->info.type == ANARI_STRING_LIST) {
-        buf.read(pi->info.asStringList);
+        buf.read(pi->info.value.asStringList);
       } else if (pi->info.type == ANARI_PARAMETER_LIST) {
-        buf.read(pi->info.asParameterList);
+        buf.read(pi->info.value.asParameterList);
       } else {
         if (!buf.eof()) {
           std::vector<char> bytes(anari::sizeOf(pi->info.type));
           buf.read(bytes.data(), bytes.size());
-          pi->info.asAny = helium::AnariAny(pi->info.type, bytes.data());
+          pi->info.value.asAny = helium::AnariAny(pi->info.type, bytes.data());
         }
       }
 

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -329,7 +329,7 @@ void Device::unsetAllParameters(ANARIObject object)
   auto buf = std::make_shared<Buffer>();
   buf->write(remoteDevice);
   buf->write(object);
-  write(MessageType::UnsetParam, buf);
+  write(MessageType::UnsetAllParams, buf);
 
   LOG(logging::Level::Info)
       << "All parameters unset on object unset on object " << object;

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -836,7 +836,7 @@ void Device::initClient()
   // request remote device to be created, send other client info along
   auto buf = std::make_shared<Buffer>();
   buf->write(remoteSubtype);
-  buf->write((const char *)&cf, sizeof(cf));
+  buf->write(cf);
   // write(MessageType::NewDevice, buf);
   //  post to queue directly: write() would call initClient() recursively!
   queue.post(std::bind(&Device::writeImpl, this, MessageType::NewDevice, buf));

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -1022,18 +1022,7 @@ void Device::handleMessage(async::connection::reason reason,
       } else if (oi->info.type == ANARI_STRING_LIST) {
         buf.read(oi->info.asStringList);
       } else if (oi->info.type == ANARI_PARAMETER_LIST) {
-        while (!buf.eof()) {
-          uint64_t len;
-          buf.read((char *)&len, sizeof(len));
-          char *name = new char[len + 1];
-          buf.read(name, len);
-          name[len] = '\0';
-
-          ANARIDataType type;
-          buf.read(type);
-          oi->info.asParameterList.push_back({name, type});
-        }
-        oi->info.asParameterList.push_back({nullptr, 0});
+        buf.read(oi->info.asParameterList);
       } else {
         if (!buf.eof()) {
           oi->info.asOther.resize(anari::sizeOf(oi->info.type));
@@ -1063,18 +1052,7 @@ void Device::handleMessage(async::connection::reason reason,
       } else if (pi->info.type == ANARI_STRING_LIST) {
         buf.read(pi->info.asStringList);
       } else if (pi->info.type == ANARI_PARAMETER_LIST) {
-        while (!buf.eof()) {
-          uint64_t len;
-          buf.read((char *)&len, sizeof(len));
-          char *name = new char[len + 1];
-          buf.read(name, len);
-          name[len] = '\0';
-
-          ANARIDataType type;
-          buf.read(type);
-          pi->info.asParameterList.push_back({name, type});
-        }
-        pi->info.asParameterList.push_back({nullptr, 0});
+        buf.read(pi->info.asParameterList);
       } else {
         if (!buf.eof()) {
           pi->info.asOther.resize(anari::sizeOf(pi->info.type));

--- a/libs/remote_device/Device.cpp
+++ b/libs/remote_device/Device.cpp
@@ -998,20 +998,16 @@ void Device::handleMessage(async::connection::reason reason,
         prop.object = property.object;
         prop.name = property.name;
 
-        uint64_t listSize;
-        buf.read(listSize);
-
-        prop.value.resize(listSize + 1);
-        prop.value[listSize] = nullptr;
-
-        for (uint64_t i = 0; i < listSize; ++i) {
+        while (!buf.eof()) {
           uint64_t strLen;
           buf.read(strLen);
 
-          prop.value[i] = new char[strLen + 1];
-          buf.read(prop.value[i], strLen);
-          prop.value[i][strLen] = '\0';
+          char *str = new char[strLen + 1];
+          buf.read(str, strLen);
+          str[strLen] = '\0';
+          prop.value.push_back(str);
         }
+        prop.value.push_back(nullptr);
 
         stringListProperties.push_back(prop);
       } else if (property.type == ANARI_DATA_TYPE_LIST) {

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -11,6 +11,7 @@
 #include "Buffer.h"
 #include "Compression.h"
 #include "Frame.h"
+#include "StringList.h"
 #include "async/connection.h"
 #include "async/connection_manager.h"
 #include "async/work_queue.h"
@@ -253,7 +254,7 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   {
     ANARIObject object{nullptr};
     std::string name;
-    std::vector<char *> value;
+    StringList value;
   };
   std::vector<StringListProperty> stringListProperties;
 
@@ -262,7 +263,7 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   struct ObjectSubtypes
   {
     ANARIDataType objectType;
-    std::vector<char *> value;
+    StringList value;
   };
   std::vector<ObjectSubtypes> objectSubtypes;
 
@@ -277,7 +278,7 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
     std::string name;
     ANARIDataType type;
     std::string asString;
-    std::vector<char *> asStringList;
+    StringList asStringList;
     std::vector<Parameter> asParameterList;
     std::vector<char> asOther;
 

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -269,23 +269,25 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   // Cache for "object infos"
   struct ObjectInfo
   {
+    typedef std::shared_ptr<ObjectInfo> Ptr;
     ANARIDataType objectType;
     std::string objectSubtype;
     std::string infoName;
     Info info;
   };
-  std::vector<ObjectInfo> objectInfos;
+  std::vector<ObjectInfo::Ptr> objectInfos;
 
   // Cache for "parameter infos"
   struct ParameterInfo
   {
+    typedef std::shared_ptr<ParameterInfo> Ptr;
     ANARIDataType objectType;
     std::string objectSubtype;
     std::string parameterName;
     ANARIDataType parameterType;
     Info info;
   };
-  std::vector<ParameterInfo> parameterInfos;
+  std::vector<ParameterInfo::Ptr> parameterInfos;
 
   std::map<ANARIObject, Frame> frames;
   struct ArrayData

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -244,18 +244,21 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   {
     std::string name;
     ANARIDataType type;
-    helium::AnariAny asAny;
-    StringList asStringList;
-    remote::ParameterList asParameterList;
+    struct
+    {
+      helium::AnariAny asAny;
+      StringList asStringList;
+      remote::ParameterList asParameterList;
+    } value;
 
     const void *data() const
     {
       if (type == ANARI_STRING_LIST)
-        return asStringList.data();
+        return value.asStringList.data();
       else if (type == ANARI_PARAMETER_LIST)
-        return asParameterList.data();
-      else if (asAny.type() != ANARI_UNKNOWN)
-        return asAny.data();
+        return value.asParameterList.data();
+      else if (value.asAny.type() != ANARI_UNKNOWN)
+        return value.asAny.data();
       else
         return nullptr;
     }

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -16,6 +16,7 @@
 #include "async/connection.h"
 #include "async/connection_manager.h"
 #include "async/work_queue.h"
+#include "utility/AnariAny.h"
 #include "utility/IntrusivePtr.h"
 #include "utility/ParameterizedObject.h"
 
@@ -243,21 +244,20 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   {
     std::string name;
     ANARIDataType type;
-    std::string asString;
+    helium::AnariAny asAny;
     StringList asStringList;
     remote::ParameterList asParameterList;
-    std::vector<char> asOther;
 
     const void *data() const
     {
-      if (type == ANARI_STRING)
-        return asString.data();
-      else if (type == ANARI_STRING_LIST)
+      if (type == ANARI_STRING_LIST)
         return asStringList.data();
       else if (type == ANARI_PARAMETER_LIST)
         return asParameterList.data();
+      else if (asAny.type() != ANARI_UNKNOWN)
+        return asAny.data();
       else
-        return asOther.data();
+        return nullptr;
     }
   };
 

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -11,6 +11,7 @@
 #include "Buffer.h"
 #include "Compression.h"
 #include "Frame.h"
+#include "ParameterList.h"
 #include "StringList.h"
 #include "async/connection.h"
 #include "async/connection_manager.h"
@@ -238,19 +239,13 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   };
   std::vector<ObjectSubtypes> objectSubtypes;
 
-  struct Parameter
-  {
-    char *name;
-    ANARIDataType type;
-  };
-
   struct Info
   {
     std::string name;
     ANARIDataType type;
     std::string asString;
     StringList asStringList;
-    std::vector<Parameter> asParameterList;
+    remote::ParameterList asParameterList;
     std::vector<char> asOther;
 
     const void *data() const

--- a/libs/remote_device/Device.h
+++ b/libs/remote_device/Device.h
@@ -178,60 +178,31 @@ struct Device : anari::DeviceImpl, helium::ParameterizedObject
   async::connection_pointer conn;
   async::work_queue queue;
 
-  struct
+  struct SyncPrimitives
   {
     std::mutex mtx;
     std::condition_variable cv;
-  } syncConnectionEstablished;
+  };
 
-  struct
+  struct SyncPoints
   {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncDeviceHandleRemote;
+    enum
+    {
+      ConnectionEstablished,
+      DeviceHandleRemote,
+      MapArray,
+      UnmapArray,
+      FrameIsReady,
+      Properties,
+      ObjectSubtypes,
+      ObjectInfo,
+      ParameterInfo,
+      // Keep last:
+      Count,
+    };
+  };
 
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncMapArray;
-
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncUnmapArray;
-
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncFrameIsReady;
-
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-    size_t which;
-  } syncProperties;
-
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncObjectSubtypes;
-
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncObjectInfo;
-
-  struct
-  {
-    std::mutex mtx;
-    std::condition_variable cv;
-  } syncParameterInfo;
+  SyncPrimitives sync[SyncPoints::Count];
 
   ANARIDevice remoteDevice{nullptr};
   std::string remoteSubtype = "default";

--- a/libs/remote_device/Frame.h
+++ b/libs/remote_device/Frame.h
@@ -18,6 +18,8 @@ struct Frame
     Mapped,
   };
 
+  uint64_t frameID{0};
+
   void resizeColor(uint32_t width, uint32_t height, ANARIDataType type);
   void resizeDepth(uint32_t width, uint32_t height, ANARIDataType type);
 

--- a/libs/remote_device/ParameterList.h
+++ b/libs/remote_device/ParameterList.h
@@ -1,0 +1,98 @@
+
+#pragma once
+
+namespace remote {
+
+struct Parameter
+{
+  char *name;
+  ANARIDataType type;
+};
+
+// RAII List type storing parameters that can be
+// converted to {const char *, type} pairs
+class ParameterList
+{
+ public:
+  ParameterList() = default;
+
+  // initialize from list of params
+  // last  pointer must be NULL!
+  ParameterList(const Parameter *parameter)
+  {
+    for (; parameter && parameter->name != nullptr; parameter++) {
+      this->push_back(std::string(parameter->name), parameter->type);
+    }
+  }
+
+  ParameterList(const ParameterList &other)
+  {
+    for (size_t i = 0; i < other.value.size(); ++i) {
+      if (other.value[i].name == nullptr)
+        value.push_back({nullptr, other.value[i].type});
+      else
+        this->push_back(std::string(other.value[i].name), other.value[i].type);
+    }
+  }
+
+  ParameterList(ParameterList &&other)
+  {
+    value = std::move(other.value);
+    other.value.clear();
+  }
+
+  ~ParameterList()
+  {
+    for (size_t i = 0; i < value.size(); ++i) {
+      delete[] value[i].name;
+    }
+  }
+
+  ParameterList &operator=(const ParameterList &other)
+  {
+    if (&other != this) {
+      for (size_t i = 0; i < other.value.size(); ++i) {
+        if (other.value[i].name == nullptr)
+          value.push_back({nullptr, other.value[i].type});
+        else
+          this->push_back(std::string(other.value[i].name), other.value[i].type);
+      }
+    }
+    return *this;
+  }
+
+  ParameterList &operator=(ParameterList &&other)
+  {
+    if (&other != this) {
+      value = std::move(other.value);
+    }
+    return *this;
+  }
+
+  void push_back(std::string name, ANARIDataType type)
+  {
+    if (name.length() > 0) {
+      char *val = new char[name.length() + 1];
+      memcpy(val, name.data(), name.length());
+      val[name.length()] = '\0';
+      value.push_back({val, type});
+    } else {
+      value.push_back({nullptr, type});
+    }
+  }
+
+  const Parameter *data() const
+  {
+    return (const Parameter *)value.data();
+  }
+
+  size_t size() const
+  {
+    return value.size();
+  }
+
+ private:
+  std::vector<Parameter> value;
+};
+
+} // namespace remote

--- a/libs/remote_device/ParameterList.h
+++ b/libs/remote_device/ParameterList.h
@@ -25,6 +25,11 @@ class ParameterList
     for (; parameter && parameter->name != nullptr; parameter++) {
       this->push_back(std::string(parameter->name), parameter->type);
     }
+
+    if (parameter != nullptr)
+      value.push_back({nullptr, parameter->type});
+    else
+      value.push_back({nullptr, ANARI_UNKNOWN});
   }
 
   ParameterList(const ParameterList &other)

--- a/libs/remote_device/ParameterList.h
+++ b/libs/remote_device/ParameterList.h
@@ -1,3 +1,5 @@
+// Copyright 2023 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/libs/remote_device/Server.cpp
+++ b/libs/remote_device/Server.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <sstream>
 #include "ArrayInfo.h"
+#include "Buffer.h"
 #include "Compression.h"
 #include "Logging.h"
 #include "async/connection.h"

--- a/libs/remote_device/Server.cpp
+++ b/libs/remote_device/Server.cpp
@@ -353,8 +353,8 @@ struct Server
 
         // return device handle and other info to client
         auto buf = std::make_shared<Buffer>();
-        buf->write((char *)&deviceHandle, sizeof(deviceHandle));
-        buf->write((char *)&cf, sizeof(cf));
+        buf->write(deviceHandle);
+        buf->write(cf);
         write(MessageType::DeviceHandle, buf);
 
         LOG(logging::Level::Info)

--- a/libs/remote_device/Server.cpp
+++ b/libs/remote_device/Server.cpp
@@ -1012,11 +1012,8 @@ struct Server
             StringList stringList((const char **)info);
             outbuf->write(stringList);
           } else if (infoType == ANARI_PARAMETER_LIST) {
-            auto *parameter = (const ANARIParameter *)info;
-            for (; parameter && parameter->name != nullptr; parameter++) {
-              outbuf->write(std::string(parameter->name));
-              outbuf->write(parameter->type);
-            }
+            ParameterList parameterList((const Parameter *)info);
+            outbuf->write(parameterList);
           } else {
             outbuf->write((const char *)info, anari::sizeOf(infoType));
           }
@@ -1082,11 +1079,8 @@ struct Server
             StringList stringList((const char **)info);
             outbuf->write(stringList);
           } else if (infoType == ANARI_PARAMETER_LIST) {
-            auto *parameter = (const ANARIParameter *)info;
-            for (; parameter && parameter->name != nullptr; parameter++) {
-              outbuf->write(std::string(parameter->name));
-              outbuf->write(parameter->type);
-            }
+            ParameterList parameterList((const Parameter *)info);
+            outbuf->write(parameterList);
           } else {
             outbuf->write((const char *)info, anari::sizeOf(infoType));
           }

--- a/libs/remote_device/Server.cpp
+++ b/libs/remote_device/Server.cpp
@@ -332,11 +332,11 @@ struct Server
       return;
     }
 
+    LOG(logging::Level::Info) << "Message: " << toString(message->type())
+        << ", message size: " << prettyBytes(message->size());
+
     if (reason == async::connection::Read) {
       if (message->type() == MessageType::NewDevice) {
-        LOG(logging::Level::Info) << "Message: NewDevice, message size: "
-                                  << prettyBytes(message->size());
-
         const char *msg = message->data();
 
         int32_t len = *(int32_t *)msg;
@@ -366,9 +366,6 @@ struct Server
         LOG(logging::Level::Info)
             << "Client has SNAPPY: " << client.compression.hasSNAPPY;
       } else if (message->type() == MessageType::NewObject) {
-        LOG(logging::Level::Info) << "Message: NewObject, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         ANARIDevice deviceHandle;
@@ -398,9 +395,6 @@ struct Server
             << "Creating new object, objectID: " << objectID
             << ", ANARI handle: " << anariObj;
       } else if (message->type() == MessageType::NewArray) {
-        LOG(logging::Level::Info) << "Message: NewArray, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         ANARIDevice deviceHandle;
@@ -437,9 +431,6 @@ struct Server
             << "Creating new array, objectID: " << objectID
             << ", ANARI handle: " << anariArr;
       } else if (message->type() == MessageType::SetParam) {
-        LOG(logging::Level::Info) << "Message: SetParam, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -495,9 +486,6 @@ struct Server
               << "Set param \"" << name << "\" on object: " << objectHandle;
         }
       } else if (message->type() == MessageType::UnsetParam) {
-        LOG(logging::Level::Info) << "Message: UnsetParam, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -521,8 +509,6 @@ struct Server
 
         anariUnsetParameter(dev, serverObj.handle, name.c_str());
       } else if (message->type() == MessageType::UnsetAllParams) {
-        LOG(logging::Level::Info) << "Message: UnsetAllParams";
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -544,9 +530,6 @@ struct Server
 
         anariUnsetAllParameters(dev, serverObj.handle);
       } else if (message->type() == MessageType::CommitParams) {
-        LOG(logging::Level::Info) << "Message: CommitParams, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         if (message->size() == sizeof(Handle)) {
@@ -587,9 +570,6 @@ struct Server
               << "Committed object. Handle: " << objectHandle;
         }
       } else if (message->type() == MessageType::Release) {
-        LOG(logging::Level::Info) << "Message: Release, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -613,9 +593,6 @@ struct Server
         LOG(logging::Level::Info)
             << "Released object. Handle: " << objectHandle;
       } else if (message->type() == MessageType::Retain) {
-        LOG(logging::Level::Info) << "Message: Retain, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -639,9 +616,6 @@ struct Server
         LOG(logging::Level::Info)
             << "Retained object. Handle: " << objectHandle;
       } else if (message->type() == MessageType::MapArray) {
-        LOG(logging::Level::Info) << "Message: MapArray, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -675,9 +649,6 @@ struct Server
 
         LOG(logging::Level::Info) << "Mapped array. Handle: " << objectHandle;
       } else if (message->type() == MessageType::UnmapArray) {
-        LOG(logging::Level::Info) << "Message: UnmapArray, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -720,9 +691,6 @@ struct Server
 
         LOG(logging::Level::Info) << "Unmapped array. Handle: " << objectHandle;
       } else if (message->type() == MessageType::RenderFrame) {
-        LOG(logging::Level::Info) << "Message: RenderFrame, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -834,9 +802,6 @@ struct Server
         LOG(logging::Level::Info)
             << "Frame rendered. Object handle: " << objectHandle;
       } else if (message->type() == MessageType::FrameReady) {
-        LOG(logging::Level::Info) << "Message: FrameReady, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -866,9 +831,6 @@ struct Server
 
         LOG(logging::Level::Info) << "Signal frame is ready to client";
       } else if (message->type() == MessageType::GetProperty) {
-        LOG(logging::Level::Info) << "Message: GetProperty, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
@@ -935,10 +897,6 @@ struct Server
         }
         write(MessageType::Property, outbuf);
       } else if (message->type() == MessageType::GetObjectSubtypes) {
-        LOG(logging::Level::Info)
-            << "Message: GetObjectSubtypes, message size: "
-            << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle;
@@ -966,9 +924,6 @@ struct Server
 
         write(MessageType::ObjectSubtypes, outbuf);
       } else if (message->type() == MessageType::GetObjectInfo) {
-        LOG(logging::Level::Info) << "Message: GetObjectInfo, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle;
@@ -1020,9 +975,6 @@ struct Server
         }
         write(MessageType::ObjectInfo, outbuf);
       } else if (message->type() == MessageType::GetParameterInfo) {
-        LOG(logging::Level::Info) << "Message: GetParameterInfo, message size: "
-                                  << prettyBytes(message->size());
-
         Buffer buf(message->data(), message->size());
 
         Handle deviceHandle;

--- a/libs/remote_device/Server.cpp
+++ b/libs/remote_device/Server.cpp
@@ -368,9 +368,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: NewObject, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         ANARIDevice deviceHandle;
         buf.read(deviceHandle);
@@ -402,14 +400,12 @@ struct Server
         LOG(logging::Level::Info) << "Message: NewArray, message size: "
                                   << prettyBytes(message->size());
 
-        ArrayInfo info;
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         ANARIDevice deviceHandle;
         buf.read(deviceHandle);
 
+        ArrayInfo info;
         buf.read(info.type);
 
         uint64_t objectID;
@@ -443,9 +439,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: SetParam, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -503,9 +497,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: UnsetParam, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -530,9 +522,7 @@ struct Server
       } else if (message->type() == MessageType::UnsetAllParams) {
         LOG(logging::Level::Info) << "Message: UnsetAllParams";
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -556,9 +546,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: CommitParams, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         if (message->size() == sizeof(Handle)) {
           // handle only => commit params of the device itself!
@@ -601,9 +589,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: Release, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -629,9 +615,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: Retain, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -657,9 +641,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: MapArray, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -695,9 +677,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: UnmapArray, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -742,9 +722,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: RenderFrame, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -858,9 +836,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: FrameReady, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -892,9 +868,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: GetProperty, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle, objectHandle;
         buf.read(deviceHandle);
@@ -983,9 +957,7 @@ struct Server
             << "Message: GetObjectSubtypes, message size: "
             << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle;
         buf.read(deviceHandle);
@@ -1017,9 +989,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: GetObjectInfo, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle;
         buf.read(deviceHandle);
@@ -1078,9 +1048,7 @@ struct Server
         LOG(logging::Level::Info) << "Message: GetParameterInfo, message size: "
                                   << prettyBytes(message->size());
 
-        Buffer buf;
-        buf.write(message->data(), message->size());
-        buf.seek(0);
+        Buffer buf(message->data(), message->size());
 
         Handle deviceHandle;
         buf.read(deviceHandle);

--- a/libs/remote_device/Server.cpp
+++ b/libs/remote_device/Server.cpp
@@ -922,17 +922,7 @@ struct Server
           outbuf->write(name);
           outbuf->write(result);
 
-          uint64_t listSize = 0;
           auto sl = stringList;
-          if (sl != nullptr) {
-            while (const char *str = *sl++) {
-              listSize++;
-            }
-          }
-
-          outbuf->write(listSize);
-
-          sl = stringList;
           if (sl != nullptr) {
             while (const char *str = *sl++) {
               outbuf->write(std::string(str));

--- a/libs/remote_device/StringList.h
+++ b/libs/remote_device/StringList.h
@@ -1,0 +1,103 @@
+
+#pragma once
+
+#include <cstring>
+#include <vector>
+
+namespace remote {
+
+// RAII List type compatible with the const char **
+// semantics of ANARI string lists
+class StringList
+{
+ public:
+  StringList() = default;
+
+  // initialize from list of const char *
+  // last pointer must be NULL!
+  StringList(const char **strings)
+  {
+    if (strings) {
+      while (auto c_str = *strings++) {
+        std::string str(c_str);
+        this->push_back(str);
+      }
+      value.push_back(nullptr);
+    }
+  }
+
+  StringList(const StringList &other)
+  {
+    for (size_t i = 0; i < other.value.size(); ++i) {
+      if (other.value[i] == nullptr)
+        value.push_back(nullptr);
+      else {
+        std::string str(other.value[i]);
+        this->push_back(str);
+      }
+    }
+  }
+
+  StringList(StringList &&other)
+  {
+    value = std::move(other.value);
+    other.value.clear();
+  }
+
+  ~StringList()
+  {
+    for (size_t i = 0; i < value.size(); ++i) {
+      delete[] value[i];
+    }
+  }
+
+  StringList &operator=(const StringList &other)
+  {
+    if (&other != this) {
+      for (size_t i = 0; i < other.value.size(); ++i) {
+        if (other.value[i] == nullptr)
+          value.push_back(nullptr);
+        else {
+          std::string str(other.value[i]);
+          this->push_back(str);
+        }
+      }
+    }
+    return *this;
+  }
+
+  StringList &operator=(StringList &&other)
+  {
+    if (&other != this) {
+      value = std::move(other.value);
+    }
+    return *this;
+  }
+
+  void push_back(std::string str)
+  {
+    if (str.length() > 0) {
+      char *val = new char[str.length() + 1];
+      memcpy(val, str.data(), str.length());
+      val[str.length()] = '\0';
+      value.push_back(val);
+    } else {
+      value.push_back(nullptr);
+    }
+  }
+
+  const char **data() const
+  {
+    return (const char **)value.data();
+  }
+
+  size_t size() const
+  {
+    return value.size();
+  }
+
+ private:
+  std::vector<char *> value;
+};
+
+} // namespace remote

--- a/libs/remote_device/StringList.h
+++ b/libs/remote_device/StringList.h
@@ -1,3 +1,5 @@
+// Copyright 2023 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/libs/remote_device/common.h
+++ b/libs/remote_device/common.h
@@ -52,6 +52,70 @@ struct MessageType
   };
 };
 
+inline const char *toString(unsigned mt)
+{
+  switch (mt) {
+  case MessageType::NewDevice:
+    return "NewDevice";
+  case MessageType::NewObject:
+    return "NewObject";
+  case MessageType::NewArray:
+    return "NewArray";
+  case MessageType::DeviceHandle:
+    return "DeviceHandle";
+  case MessageType::SetParam:
+    return "SetParam";
+  case MessageType::UnsetParam:
+    return "UnsetParam";
+  case MessageType::UnsetAllParams:
+    return "UnsetAllParams";
+  case MessageType::CommitParams:
+    return "CommitParams";
+  case MessageType::Release:
+    return "Release";
+  case MessageType::Retain:
+    return "Retain";
+  case MessageType::ArrayData:
+    return "ArrayData";
+  case MessageType::MapArray:
+    return "MapArray";
+  case MessageType::ArrayMapped:
+    return "ArrayMapped";
+  case MessageType::UnmapArray:
+    return "UnmapArray";
+  case MessageType::ArrayUnmapped:
+    return "ArrayUnmapped";
+  case MessageType::RenderFrame:
+    return "RenderFrame";
+  case MessageType::FrameReady:
+    return "FrameReady";
+  case MessageType::FrameIsReady:
+    return "FrameIsReady";
+  case MessageType::GetProperty:
+    return "GetProperty";
+  case MessageType::Property:
+    return "Property";
+  case MessageType::GetObjectSubtypes:
+    return "GetObjectSubtypes";
+  case MessageType::ObjectSubtypes:
+    return "ObjectSubtypes";
+  case MessageType::GetObjectInfo:
+    return "GetObjectInfo";
+  case MessageType::ObjectInfo:
+    return "ObjectInfo";
+  case MessageType::GetParameterInfo:
+    return "GetParameterInfo";
+  case MessageType::ParameterInfo:
+    return "ParameterInfo";
+  case MessageType::ChannelColor:
+    return "CannelColor";
+  case MessageType::ChannelDepth:
+    return "ChannelDepth";
+  default:
+    return "Unknown";
+  }
+}
+
 typedef int64_t Handle;
 
 inline std::string prettyNumber(const size_t s)


### PR DESCRIPTION
This is a cleanup PR that improves maintainability of the remote device. It consolidates object and parameter queries using special list types, moves some of the common logging code into functions, and fixes an issue where the wrong message type was used when calling `anariUnsetAllParameters(...)`. Also, the worker and message queue synchronization got streamlined using a common type wrapping synchronization primitives and synchronization points.