### PR TITLE
Various small improvements

### DIFF
--- a/cts/CMakeLists.txt
+++ b/cts/CMakeLists.txt
@@ -42,7 +42,7 @@ PUBLIC
 
 target_link_libraries(${PROJECT_NAME} PUBLIC glm::glm helium anari_test_scenes)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
 file(GLOB python_files ${CMAKE_CURRENT_LIST_DIR}/*.py)
 

--- a/libs/anari/API.cpp
+++ b/libs/anari/API.cpp
@@ -15,6 +15,7 @@
 #include <stdexcept>
 #include <string>
 
+#ifdef ANARI_FRONTEND_CATCH_EXCEPTIONS
 #define ANARI_CATCH_BEGIN try {
 #define ANARI_CATCH_END(a)                                                     \
   }                                                                            \
@@ -33,6 +34,10 @@
     std::terminate();                                                          \
     return a;                                                                  \
   }
+#else
+#define ANARI_CATCH_BEGIN {
+#define ANARI_CATCH_END(a) }
+#endif
 #define ANARI_NORETURN /**/
 #define ANARI_CATCH_END_NORETURN() ANARI_CATCH_END(ANARI_NORETURN)
 

--- a/libs/anari/CMakeLists.txt
+++ b/libs/anari/CMakeLists.txt
@@ -1,6 +1,9 @@
 ## Copyright 2021 The Khronos Group
 ## SPDX-License-Identifier: Apache-2.0
 
+option(ANARI_FRONTEND_CATCH_EXCEPTIONS "Have libanari catch all exceptions" ON)
+mark_as_advanced(ANARI_FRONTEND_CATCH_EXCEPTIONS)
+
 project_add_library(
   anari_cpp_linalg_defs.cpp
   anari_cpp_std_defs.cpp
@@ -15,6 +18,10 @@ endif()
 
 if (WIN32)
   project_compile_definitions(PUBLIC -D_USE_MATH_DEFINES)
+endif()
+
+if (ANARI_FRONTEND_CATCH_EXCEPTIONS)
+  project_compile_definitions(PRIVATE -DANARI_FRONTEND_CATCH_EXCEPTIONS)
 endif()
 
 project_include_directories(

--- a/libs/anari/include/anari/anari_cpp/ext/linalg.h
+++ b/libs/anari/include/anari/anari_cpp/ext/linalg.h
@@ -767,6 +767,11 @@ inline float radians(float degrees)
   return degrees * float(M_PI) / 180.f;
 }
 
+inline float degrees(float radians)
+{
+  return radians * 180.f / float(M_PI);
+}
+
 } // namespace anari
 
 #endif


### PR DESCRIPTION
- Make sure Python headers are present when CTS is being built
- Add radians conversion function
- Add CMake option to allow bypassing the catch-all for exceptions through the C API