### PR TITLE
Update anariConfig.cmake.in on next_release branch

### DIFF
--- a/cmake/anariConfig.cmake.in
+++ b/cmake/anariConfig.cmake.in
@@ -47,3 +47,4 @@ elseif(anari_FIND_REQUIRED_viewer)
 endif()
 
 check_required_components(@PROJECT_NAME@)
+set(ANARI_FOUND TRUE)


### PR DESCRIPTION
Adding back setting ANARI_FOUND. This is used in VisIt to determine if find_package succeeded which results in creating other CMake cache variables that are needed to support ANARI integration.