### PR TITLE
Fix a misplaced } in generate_headers.py

### DIFF
--- a/code_gen/generate_headers.py
+++ b/code_gen/generate_headers.py
@@ -366,6 +366,8 @@ R anariTypeInvoke(ANARIDataType type, Args&&... args) {
         f.write('    }\n')
         f.write('}\n')
 
+        f.write('}\n')
+
         f.write('#endif\n')
 
 
@@ -435,8 +437,6 @@ inline int isNormalized(ANARIDataType type) {
             f.write('        case '+enum['name']+': return '+str(int(enum['normalized']))+';\n')
         f.write('        default: return 0;\n')
         f.write('    }\n')
-        f.write('}\n')
-
         f.write('}\n')
 
 output = sys.argv[1]


### PR DESCRIPTION
Fixes a misplaced `}` in the `type_utility.h` generator. The `}` now correctly closes the `anari` namespace before the `#endif` paired to `#define __cplusplus`.