### PR TITLE
Add environment variables for debug device tracing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ independently from the SDK. (see below)
 
 ### Using the debug device layer
 
-The ANARI-SDK ships with a [debug layer](src/debug) implemented as an ordinary
+The ANARI-SDK ships with a [debug layer](src/debug_device) implemented as an ordinary
 `ANARIDevice` which wraps a device (set as the `wrappedDevice` parameter on the
 debug device). This device uses the object queries reported by the wrapped
 device to validate correct usage of object subtypes, parameters, and properties,

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ how to setup the debug device without using environment variables.
 Note that if `ANARI_DEBUG_WRAPPED_LIBRARY` is set, it will take priority over
 programatically set wrapped devices.
 
+Tracing features of the debug device can be set using the following environment
+variables:
+- `ANARI_DEBUG_TRACE_MODE` sets the tracing mode, only `code` is supported for now.
+- `ANARI_DEBUG_TRACE_DIR` set the folder where the trace will be dumped.
+
 ### Unofficial list of publically available implementaions
 
 Below is a list of available ANARI implemenations compatible with this SDK:

--- a/src/debug_device/DebugDevice.cpp
+++ b/src/debug_device/DebugDevice.cpp
@@ -8,6 +8,7 @@
 #include "CodeSerializer.h"
 #include "DebugBasics.h"
 #include "EmptySerializer.h"
+#include "anari/frontend/anari_enums.h"
 
 // std
 #include <cstdarg>
@@ -1002,6 +1003,16 @@ DebugDevice::DebugDevice(ANARILibrary library)
       wrapped = staged = anariNewDevice(library, "default");
     }
   }
+
+  const char *traceModeFromEnv = getenv("ANARI_DEBUG_TRACE_MODE");
+  const char *traceDirFromEnv = getenv("ANARI_DEBUG_TRACE_DIR");
+  if (traceModeFromEnv && traceDirFromEnv) {
+    anariSetParameter(this_device(), this_device(), "traceMode", ANARI_STRING, traceModeFromEnv);
+    anariSetParameter(this_device(), this_device(), "traceDir", ANARI_STRING, traceDirFromEnv);
+    anariCommitParameters(this_device(), this_device());
+  }
+  
+
 }
 
 DebugDevice::~DebugDevice()

--- a/src/hdanari/renderDelegate.cpp
+++ b/src/hdanari/renderDelegate.cpp
@@ -136,39 +136,6 @@ void HdAnariRenderDelegate::Initialize()
     return;
   }
 
-  bool useDebugDevice = false;
-  TF_DEBUG_MSG(HD_ANARI_RENDERDELEGATE, "Check for debug device selection\n");
-
-  if (auto enableDebug_s = std::getenv("HDANARI_ENABLE_DEBUG"); enableDebug_s) {
-    if (auto enableDebug = std::string(enableDebug_s); enableDebug == "1") {
-      useDebugDevice = true;
-    } else if (enableDebug != "0" && enableDebug != "") {
-      TF_WARN(
-          "Unknown HDANARI_ENABLE_DEBUG value %s. Must be undefined or set to 0 or 1",
-          enableDebug.c_str());
-    }
-  }
-
-  if (useDebugDevice) {
-    TF_DEBUG_MSG(HD_ANARI_RENDERDELEGATE, "Enabling debug device\n");
-    auto debugLib = anari::loadLibrary("debug", hdAnariDeviceStatusFunc);
-    if (!debugLib) {
-      TF_RUNTIME_ERROR("failed to load ANARI debug library from environment");
-    }
-
-    anari::Device dbgDevice = anariNewDevice(debugLib, "debug");
-    anari::setParameter(dbgDevice, dbgDevice, "wrappedDevice", device);
-    if (auto traceDir_s = std::getenv("HDANARI_DEBUG_TRACE_DIR"); traceDir_s) {
-      if (auto traceDir = std::string(traceDir_s); !traceDir.empty()) {
-        anari::setParameter(dbgDevice, dbgDevice, "traceDir", traceDir.c_str());
-        anari::setParameter(dbgDevice, dbgDevice, "traceMode", "code");
-      }
-    }
-    anari::commitParameters(dbgDevice, dbgDevice);
-    anari::release(device, device);
-    device = dbgDevice;
-  }
-
   _renderParam = std::make_shared<HdAnariRenderParam>(device);
 
   std::lock_guard<std::mutex> guard(_mutexResourceRegistry);


### PR DESCRIPTION
Exposes two additions environment variables, beside the existing ANARI_DEBUG_WRAPPED_LIBRARY:
- `ANARI_DEBUG_TRACE_MODE` sets the tracing mode.
- `ANARI_DEBUG_TRACE_DIR` set the folder where the trace will be dumped.