### PR TITLE
Kill alpha on rgb only inputs

### DIFF
--- a/src/hdanari/material.cpp
+++ b/src/hdanari/material.cpp
@@ -177,6 +177,12 @@ std::map<SdfPath, anari::Sampler> HdAnariMaterial::CreateSamplers(
         "outTransform",
         ANARI_FLOAT32_MAT4,
         desc.transform.data());
+    
+    anari::setParameter(device,
+        sampler,
+        "outOffset",
+        ANARI_FLOAT32_VEC4,
+        desc.offset.data());
 
     anari::commitParameters(device, sampler);
 

--- a/src/hdanari/material/textureLoader.h
+++ b/src/hdanari/material/textureLoader.h
@@ -34,6 +34,7 @@ public:
       0.0f, 0.0f, 1.0f, 0.0f,
       0.0f, 0.0f, 0.0f, 1.0f,
       };
+    std::array<float, 4> offset = { 0.0f, 0.0f, 0.0f, 0.0f };
   };
 
   static anari::DataType HioFormatToAnari(HioFormat f);

--- a/src/hdanari/material/usdPreviewSurfaceConverter.cpp
+++ b/src/hdanari/material/usdPreviewSurfaceConverter.cpp
@@ -102,9 +102,19 @@ HdAnariUsdPreviewSurfaceConverter::EnumerateTextures(
       0.0f, 0.0f, 1.0f, 0.0f,
       0.0f, 0.0f, 0.0f, 1.0f,
       };
+    auto offset = std::array{0.0f, 0.0f, 0.0f, 0.0f};
+
     // If connnected to a specific channel, swizzle the color components to
     // mimic the connection behavior
-    if (outputName == HdAnariMaterialTokens->r) {
+    if (outputName == HdAnariMaterialTokens->rgb) {
+      tx = std::array{
+        1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 0.0f,
+      };
+      offset[3] = 1.0f;
+    } else if (outputName == HdAnariMaterialTokens->r) {
       // clang-format off
       tx = {
           1.0f, 1.0f, 1.0f, 1.0f,
@@ -150,7 +160,8 @@ HdAnariUsdPreviewSurfaceConverter::EnumerateTextures(
       assetPath,
       colorspace,
        HdAnariTextureLoader::MinMagFilter::Linear, // FIXME: Should be coming from the UsdShade node instead
-       tx
+       tx,
+       offset,
     };
   }
 

--- a/src/hdanari/materialTokens.h
+++ b/src/hdanari/materialTokens.h
@@ -27,6 +27,7 @@
   (opacityThreshold) \
   (r) \
   (raw) \
+  (rgb) \
   (roughness) \
   (scale) \
   (sourceColorSpace) \


### PR DESCRIPTION
Otherwise, alpha might end up being applied twice if combined with an opacity map