### PR TITLE
Queries: remove default 'isovalue', it is required

### DIFF
--- a/code_gen/api/khr_geometry_isosurface.json
+++ b/code_gen/api/khr_geometry_isosurface.json
@@ -86,8 +86,7 @@
                     "name" : "isovalue",
                     "types" : ["ANARI_FLOAT32", "ANARI_ARRAY1D"],
                     "elementType" : ["ANARI_FLOAT32"],
-                    "tags" : [],
-                    "default" : 0.5,
+                    "tags" : ["required"],
                     "description" : "isovalue(s) defining the isosurface(s)"
                 }, {
                     "name" : "field",


### PR DESCRIPTION
fixes https://github.com/KhronosGroup/ANARI-SDK/pull/229#discussion_r1745330533