### PR TITLE
ci: Build dependency for Github Actions

### DIFF
--- a/.github/workflows/anari_sdk_ci.yml
+++ b/.github/workflows/anari_sdk_ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         config: [Release, Debug]
 
     steps:
@@ -23,6 +23,46 @@ jobs:
     - name: Install Packages
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: sudo apt install -y libboost-system-dev
+
+    - name: Configure CMake
+      run: >
+        cmake -LA -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
+        -DBUILD_SHARED_LIBS=ON
+        -DBUILD_EXAMPLES=ON
+        -DBUILD_HDANARI=OFF
+        -DBUILD_HELIDE_DEVICE=ON
+        -DBUILD_REMOTE_DEVICE=${{ matrix.os == 'ubuntu-latest' }}
+        -DBUILD_TESTING=ON
+        -DBUILD_VIEWER=OFF
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config }} --target install
+
+    - name: Unit Tests
+      working-directory: ${{github.workspace}}/build
+      run: ctest -R unit_test -C ${{ matrix.config }}
+
+    - name: Render Tests
+      working-directory: ${{github.workspace}}/build
+      run: ctest -R render_test -C ${{ matrix.config }}
+
+    - name: Tutorial Tests
+      working-directory: ${{github.workspace}}/build
+      run: ctest -R anariTutorial -C ${{ matrix.config }}
+  
+  build-macos:
+    # iOS is 10x expensive to run on GitHub machines, so only run if we know something else passed as well
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        config: [Release]
+
+    steps:
+    - uses: actions/checkout@v3
 
     - name: Configure CMake
       run: >


### PR DESCRIPTION
Recently we have found productivty slow down in other KhronosGroups repos because it can take hours for CI to run due to running out of Github Actions minutes. We have found that MacOS/iOS are charged as 10x the minute cost which really starts to add up. The goal is to not have those expensive CI actions run unless we know other things work first.

(There is an internal issue on this, but for short term, I have just been apply these types of YAML chanegs aroudn the repos https://gitlab.khronos.org/khronos-general/khronos-issues/-/issues/127)