### PR TITLE
Codegen skips bindings if Python module not found

### DIFF
--- a/code_gen/CMakeLists.txt
+++ b/code_gen/CMakeLists.txt
@@ -71,6 +71,11 @@ add_custom_target(generate_headers DEPENDS
 
 add_dependencies(generate_all generate_headers)
 
+if (NOT TARGET Python3::Module)
+  message(WARNING "Unable to find python Module, skipping python bindings")
+  return()
+endif()
+
 if (INSTALL_PYTHON_BINDINGS)
   set(BUILD_PYTHON_BINDINGS_BY_DEFAULT ALL)
 endif()


### PR DESCRIPTION
Simply skips the python bindings of the codegen project, instead of erroring in case python module is not found