### PR TITLE
Enable setting output location of the generated queries files

### DIFF
--- a/cmake/anari_generate_codegen.cmake
+++ b/cmake/anari_generate_codegen.cmake
@@ -12,7 +12,7 @@ function(anari_generate_queries)
   # options
     ""
   # single-arg options
-    "PREFIX;NAME;CPP_NAMESPACE;JSON_DEFINITIONS_FILE;JSON_ROOT_LOCATION"
+    "PREFIX;NAME;CPP_NAMESPACE;JSON_DEFINITIONS_FILE;JSON_ROOT_LOCATION;OUTPUT_LOCATION"
   # multi-arg options
     ""
   # string to parse
@@ -29,6 +29,12 @@ function(anari_generate_queries)
     set(EXTRA_JSON_OPTION --json ${GENERATE_JSON_ROOT_LOCATION})
   endif()
 
+  if (DEFINED GENERATE_OUTPUT_LOCATION)
+    set(OUTPUT_LOCATION ${GENERATE_OUTPUT_LOCATION})
+  else()
+    set(OUTPUT_LOCATION ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
   add_custom_target(generate_${GENERATE_NAME}
     COMMAND ${Python3_EXECUTABLE} ${ANARI_CODE_GEN_ROOT}/generate_queries.py
       --json ${ANARI_CODE_GEN_ROOT}
@@ -36,8 +42,14 @@ function(anari_generate_queries)
       --prefix ${GENERATE_PREFIX}
       --device ${GENERATE_JSON_DEFINITIONS_FILE}
       --namespace ${GENERATE_CPP_NAMESPACE}
+      --output ${OUTPUT_LOCATION}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${GENERATE_JSON_DEFINITIONS_FILE}
+  )
+
+  set_source_files_properties(
+    ${OUTPUT_LOCATION}/${GENERATE_PREFIX}Queries.h ${OUTPUT_LOCATION}/${GENERATE_PREFIX}Queries.cpp
+    PROPERTIES GENERATED ON
   )
 
   if (TARGET generate_all)


### PR DESCRIPTION
This can be used to have build configuration dependent queries baked in the device code.