### PR TITLE
Set texture wrapping to clamp_to_edge in anari_viewer's viewport.

### DIFF
--- a/src/anari_viewer/windows/Viewport.cpp
+++ b/src/anari_viewer/windows/Viewport.cpp
@@ -30,6 +30,8 @@ Viewport::Viewport(anari::Device device, const char *name)
   glBindTexture(GL_TEXTURE_2D, m_framebufferTexture);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexImage2D(GL_TEXTURE_2D,
       0,
       GL_RGBA8,


### PR DESCRIPTION
This fixes the rendering issues at the borders of the viewport.