### PR TITLE
Introduce GeomSubset support to meshes

### DIFF
--- a/src/hdanari/geometry.cpp
+++ b/src/hdanari/geometry.cpp
@@ -3,9 +3,21 @@
 
 #include "geometry.h"
 
+#include "anariTokens.h"
+#include "debugCodes.h"
+#include "instancer.h"
+#include "material.h"
+#include "renderParam.h"
+
+// anari
 #include <anari/anari.h>
 #include <anari/anari_cpp/Traits.h>
 #include <anari/frontend/anari_enums.h>
+#include <anari/frontend/type_utility.h>
+#include <anari/anari_cpp.hpp>
+#include <anari/anari_cpp/anari_cpp_impl.hpp>
+
+// pxr
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/matrix4f.h>
 #include <pxr/base/gf/vec2f.h>
@@ -15,30 +27,35 @@
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/tf.h>
+#include <pxr/base/tf/token.h>
 #include <pxr/base/trace/staticKeyData.h>
 #include <pxr/base/trace/trace.h>
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/types.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/changeTracker.h>
+#include <pxr/imaging/hd/enums.h>
 #include <pxr/imaging/hd/extComputationUtils.h>
 #include <pxr/imaging/hd/instancer.h>
 #include <pxr/imaging/hd/perfLog.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/rprim.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/types.h>
 #include <pxr/pxr.h>
-#include <stdint.h>
+
 #include <algorithm>
-#include <anari/anari_cpp.hpp>
-#include <anari/anari_cpp/anari_cpp_impl.hpp>
+#include <array>
+#include <cassert>
+#include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <iterator>
+#include <map>
 #include <numeric>
 #include <unordered_map>
 #include <utility>
-
-#include "anariTokens.h"
-#include "debugCodes.h"
-#include "instancer.h"
-#include "renderParam.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -58,7 +75,7 @@ static bool _GetVtArrayBufferData_T(
   return false;
 }
 
-static bool _GetVtArrayBufferData(
+bool HdAnariGeometry::_GetVtArrayBufferData(
     VtValue v, const void **data, size_t *size, anari::DataType *type)
 {
   if (_GetVtArrayBufferData_T<VtIntArray>(v, data, size, type))
@@ -108,7 +125,7 @@ static bool _GetVtValueArrayAsAttribute_T(VtValue v, GfVec4f &out)
   return false;
 }
 
-static bool _GetVtValueAsAttribute(VtValue v, GfVec4f &out)
+bool HdAnariGeometry::_GetVtValueAsAttribute(VtValue v, GfVec4f &out)
 {
   if (_GetVtValueAsAttribute_T<float>(v, out))
     return true;
@@ -133,49 +150,191 @@ HdAnariGeometry::HdAnariGeometry(anari::Device d,
     const TfToken &geometryType,
     const SdfPath &id,
     const SdfPath &instancerId)
-    : HdMesh(id)
+    : HdMesh(id), geometryType_(geometryType)
 {
   if (!d)
     return;
 
-  _anari.device = d;
-  _anari.geometry =
-      anari::newObject<anari::Geometry>(d, geometryType.GetText());
-  _anari.surface = anari::newObject<anari::Surface>(d);
-  _anari.group = anari::newObject<anari::Group>(d);
-#if USE_INSTANCE_ARRAYS
-  _anari.instance = anari::newObject<anari::Instance>(d, "transform");
-#endif
-
-  anari::setParameter(d, _anari.surface, "geometry", _anari.geometry);
-  anari::commitParameters(d, _anari.surface);
-
-  anari::setParameterArray1D(d, _anari.group, "surface", &_anari.surface, 1);
-  anari::commitParameters(d, _anari.group);
-
-#if USE_INSTANCE_ARRAYS
-  anari::setParameter(_anari.device, _anari.instance, "group", _anari.group);
-  anari::commitParameters(d, _anari.instance);
-#endif
+  device_ = d;
 }
 
 HdAnariGeometry::~HdAnariGeometry()
 {
-  if (!_anari.device)
+  if (!device_)
     return;
-#if USE_INSTANCE_ARRAYS
-  anari::release(_anari.device, _anari.instance);
-#else
-  ReleaseInstances();
-#endif
-  anari::release(_anari.device, _anari.group);
-  anari::release(_anari.device, _anari.surface);
-  anari::release(_anari.device, _anari.geometry);
 }
 
 HdDirtyBits HdAnariGeometry::GetInitialDirtyBitsMask() const
 {
   return HdChangeTracker::AllDirty;
+}
+
+// Updates an anari geometry object.
+// primvarSource stores the usable values to populate the geometry.
+// updatedPrimvarsBinding stores the binding points for the primvars for this
+// new sync. previousPrimvarsBinding stores the binding points for the primvars
+// for the previous sync. updates stores the primvars that have been added or
+// updated. removes stores the primvars that have been removed.
+void HdAnariGeometry::SyncAnariGeometry(anari::Device device,
+    anari::Geometry geometry,
+
+    const PrimvarToSource &primvarSources,
+    HdAnariMaterial::PrimvarBinding updatedPrimvarsBinding,
+    HdAnariMaterial::PrimvarBinding previousPrimvarsBinding,
+
+    const PrimvarStateDesc &updates,
+    const PrimvarStateDesc &removes)
+{
+  // Traverse all removed primvars and find a possible previous binding point to
+  // clear.
+  for (auto primvar : removes.primvars) {
+    auto bindingPointIt = previousPrimvarsBinding.find(primvar);
+    if (bindingPointIt == cend(previousPrimvarsBinding))
+      continue;
+
+    auto interpolationIt = removes.primvarsInterpolation.find(primvar);
+    if (interpolationIt == cend(removes.primvarsInterpolation))
+      continue;
+
+    auto bindingPoint = bindingPointIt->second;
+    auto interpolation = interpolationIt->second;
+
+    // Skip interpolation primvars as those are of interest to anari::Instance
+    // only.
+    if (interpolation == HdInterpolationInstance)
+      continue;
+
+    anari::unsetParameter(device,
+        geometry,
+        _GetBindingPoint(bindingPoint, interpolation).GetText());
+  }
+
+  // Traverse all added/updated primvars and the new binding point to set.
+  for (auto primvar : updates.primvars) {
+    auto primvarSourceIt = primvarSources.find(primvar);
+    if (primvarSourceIt == cend(primvarSources))
+      continue;
+
+    auto bindingPointIt = updatedPrimvarsBinding.find(primvar);
+    if (bindingPointIt == cend(updatedPrimvarsBinding))
+      continue;
+
+    auto interpolationIt = updates.primvarsInterpolation.find(primvar);
+    if (interpolationIt == cend(updates.primvarsInterpolation))
+      continue;
+
+    auto bindingPoint = bindingPointIt->second;
+    auto interpolation = interpolationIt->second;
+
+    if (interpolation == HdInterpolationInstance)
+      continue;
+
+    switch (interpolation) {
+    case HdInterpolationConstant: {
+      anari::setParameter(device,
+          geometry,
+          bindingPoint.GetText(),
+          std::get<GfVec4f>(primvarSourceIt->second));
+      break;
+    }
+    case HdInterpolationFaceVarying:
+    case HdInterpolationVarying:
+    case HdInterpolationVertex:
+    case HdInterpolationUniform: {
+      bindingPoint = _GetBindingPoint(bindingPoint, interpolation);
+      anari::setParameter(device,
+          geometry,
+          bindingPoint.GetText(),
+          std::get<anari::Array1D>(primvarSourceIt->second));
+      break;
+    }
+    case HdInterpolationInstance: {
+      break;
+    }
+
+    case HdInterpolationCount: {
+      assert(false);
+    }
+    }
+  }
+}
+
+// Updates an anari instance object.
+// primvarSource stores the usable values to populate the geometry.
+// updatedPrimvarsBinding stores the binding points for the primvars for this
+// new sync. previousPrimvarsBinding stores the binding points for the primvars
+// for the previous sync. updates stores the primvars that have been added or
+// updated. removes stores the primvars that have been removed.
+void HdAnariGeometry::SyncAnariInstance(anari::Device device,
+    anari::Instance instance,
+    const PrimvarToSource &primvarSources,
+    HdAnariMaterial::PrimvarBinding updatedPrimvarsBinding,
+    HdAnariMaterial::PrimvarBinding previousPrimvarsBinding,
+
+    const PrimvarStateDesc &updates,
+    const PrimvarStateDesc &removes)
+{
+  // Traverse all removed primvars and find a possible previous binding point to
+  // clear.
+  for (auto primvar : removes.primvars) {
+    auto bindingPointIt = previousPrimvarsBinding.find(primvar);
+    if (bindingPointIt == cend(previousPrimvarsBinding))
+      continue;
+
+    auto interpolationIt = removes.primvarsInterpolation.find(primvar);
+    if (interpolationIt == cend(removes.primvarsInterpolation))
+      continue;
+
+    auto bindingPoint = bindingPointIt->second;
+    auto interpolation = interpolationIt->second;
+
+    // Only deal with instance primvars.
+    if (interpolation != HdInterpolationInstance)
+      continue;
+
+    anari::unsetParameter(device,
+        instance,
+        _GetBindingPoint(bindingPoint, interpolation).GetText());
+  }
+
+  // Traverse all added/updated primvars and the new binding point to set.
+  for (auto primvar : updates.primvars) {
+    auto primvarSourceIt = primvarSources.find(primvar);
+    if (primvarSourceIt == cend(primvarSources))
+      continue;
+
+    auto bindingPointIt = updatedPrimvarsBinding.find(primvar);
+    if (bindingPointIt == cend(updatedPrimvarsBinding))
+      continue;
+
+    auto interpolationIt = updates.primvarsInterpolation.find(primvar);
+    if (interpolationIt == cend(updates.primvarsInterpolation))
+      continue;
+
+    auto bindingPoint = bindingPointIt->second;
+    auto interpolation = interpolationIt->second;
+
+    switch (interpolation) {
+    case HdInterpolationInstance: {
+      anari::setParameter(device,
+          instance,
+          bindingPoint.GetText(),
+          std::get<anari::Array1D>(primvarSourceIt->second));
+      break;
+    }
+
+    case HdInterpolationConstant:
+    case HdInterpolationUniform:
+    case HdInterpolationVarying:
+    case HdInterpolationVertex:
+    case HdInterpolationFaceVarying:
+      break;
+
+    case HdInterpolationCount: {
+      assert(false);
+    }
+    }
+  }
 }
 
 void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
@@ -187,7 +346,7 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   HF_MALLOC_TAG_FUNCTION();
 
   auto *renderParam = static_cast<HdAnariRenderParam *>(renderParam_);
-  if (!renderParam || !_anari.device)
+  if (!renderParam || !device_)
     return;
 
   HdRenderIndex &renderIndex = sceneDelegate->GetRenderIndex();
@@ -195,6 +354,9 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
 
   // update our own instancer data.
   _UpdateInstancer(sceneDelegate, dirtyBits);
+
+  auto instancer = static_cast<HdAnariInstancer *>(
+      renderIndex.GetInstancer(GetInstancerId()));
 
   // Make sure we call sync on parent instancers.
   // XXX: In theory, this should be done automatically by the render index.
@@ -207,53 +369,17 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   // Handle material sync first
   SetMaterialId(sceneDelegate->GetMaterialId(id));
 
-  HdAnariMaterial::PrimvarBinding previousBinding = primvarBinding_;
-  HdAnariMaterial::PrimvarBinding updatedPrimvarBinding = previousBinding;
-  if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-    HdAnariMaterial *material = static_cast<HdAnariMaterial *>(
-        renderIndex.GetSprim(HdPrimTypeTokens->material, GetMaterialId()));
-    if (auto mat = material ? material->GetAnariMaterial() : nullptr) {
-      anari::setParameter(_anari.device,
-          _anari.surface,
-          "material",
-          material->GetAnariMaterial());
-      updatedPrimvarBinding = material->GetPrimvarBinding();
-    } else {
-      anari::setParameter(_anari.device,
-          _anari.surface,
-          "material",
-          renderParam->GetDefaultMaterial());
-      updatedPrimvarBinding = renderParam->GetDefaultPrimvarBinding();
-    }
-    anari::commitParameters(_anari.device, _anari.surface);
-  }
-
-  // Enumerate primvars
+  // Enumerate primvars defiend on the geometry. Compute first, then plain.
+  std::vector<TfToken> allPrimvars;
   bool pointsIsComputationPrimvar = false;
-  bool displayColorIsAuthored = false;
-  TfToken::Set allPrimvars;
-  HdExtComputationPrimvarDescriptorVector computationPrimvarDescriptors;
+  bool displayColorIsAuthored =
+      false; // Will be used to handle assigning a default value if needed.
   for (auto i = 0; i < HdInterpolationCount; ++i) {
     auto interpolation = HdInterpolation(i);
 
     for (const auto &pv : sceneDelegate->GetExtComputationPrimvarDescriptors(
              id, HdInterpolation(i))) {
-      allPrimvars.insert(pv.name);
-
-      // Consider the primvar if it is dirty and is part of the new binding set
-      TfToken prevBindingPoint;
-      TfToken newBindingPoint;
-      if (auto it = previousBinding.find(pv.name);
-          it != std::cend(previousBinding))
-        prevBindingPoint = it->second;
-      if (auto it = updatedPrimvarBinding.find(pv.name);
-          it != std::cend(updatedPrimvarBinding))
-        newBindingPoint = it->second;
-
-      if (prevBindingPoint != newBindingPoint
-          || HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, pv.name)) {
-        computationPrimvarDescriptors.push_back(pv);
-      }
+      allPrimvars.push_back(pv.name);
       if (pv.name == HdTokens->points)
         pointsIsComputationPrimvar = true;
       if (pv.name == HdTokens->displayColor)
@@ -261,144 +387,273 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
     }
   }
 
-  HdPrimvarDescriptorVector primvarDescriptors;
   for (auto i = 0; i < HdInterpolationCount; ++i) {
     for (const auto &pv :
         sceneDelegate->GetPrimvarDescriptors(GetId(), HdInterpolation(i))) {
-      if (auto it = allPrimvars.find(pv.name); it != std::cend(allPrimvars))
-        continue;
-
-      allPrimvars.insert(pv.name);
-      // Consider the primvar if it is dirty and is part of the new binding set
-      TfToken prevBindingPoint;
-      TfToken newBindingPoint;
-      if (auto it = previousBinding.find(pv.name);
-          it != std::cend(previousBinding))
-        prevBindingPoint = it->second;
-      if (auto it = updatedPrimvarBinding.find(pv.name);
-          it != std::cend(updatedPrimvarBinding))
-        newBindingPoint = it->second;
-
-      if (prevBindingPoint != newBindingPoint
-          || HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, pv.name)) {
-        primvarDescriptors.push_back(pv);
-      }
+      allPrimvars.push_back(pv.name);
       if (pv.name == HdTokens->displayColor)
         displayColorIsAuthored = true;
     }
   }
+  // Make sure this is stored we can do binary searches and set differences.
+  std::sort(begin(allPrimvars), end(allPrimvars));
 
-  // Drop all previous primvars that are not part of the new material
-  // description or are bound to a different point.
-  for (const auto &pvb : previousBinding) {
-    if (auto it = updatedPrimvarBinding.find(pvb.first);
-        it == std::cend(updatedPrimvarBinding) || it->second != pvb.second) {
-      if (auto geomIt = geometryBindingPoints_.find(pvb.second);
-          geomIt != std::cend(geometryBindingPoints_)) {
-        anari::unsetParameter(
-            _anari.device, _anari.geometry, geomIt->second.GetText());
-      } else if (auto instanceIt = instanceBindingPoints_.find(pvb.second);
-                 instanceIt != std::cend(instanceBindingPoints_)) {
-#if USE_INSTANCE_ARRAYS
-        anari::unsetParameter(
-            _anari.device, _anari.instance, instanceIt->second.GetText());
-#endif
+  // Get an exhaustive list of primvars used by the different materials
+  // referenced this geometry and its subsets.
+  std::vector<TfToken> activePrimvars;
+
+  // Check for dirty primvars and primvars that are actually used
+  // Handle all primvars from the main geometry and all geomsubsets.
+  // Main geometry first...
+  GeomSubsetInfo mainGeomInfo;
+
+  HdAnariMaterial *material = static_cast<HdAnariMaterial *>(
+      renderIndex.GetSprim(HdPrimTypeTokens->material, GetMaterialId()));
+  if (auto mat = material ? material->GetAnariMaterial() : nullptr) {
+    mainGeomInfo.material = material->GetAnariMaterial();
+    mainGeomInfo.primvarBinding = material->GetPrimvarBinding();
+  } else {
+    mainGeomInfo.material = renderParam->GetDefaultMaterial();
+    mainGeomInfo.primvarBinding = renderParam->GetDefaultPrimvarBinding();
+  }
+
+  // Points and normals are implicit bindings
+  mainGeomInfo.primvarBinding.insert(
+      {HdTokens->points, HdAnariTokens->position});
+  mainGeomInfo.primvarBinding.insert(
+      {HdTokens->normals, HdAnariTokens->normal});
+
+  // Same with transforms and ids for instancing
+  mainGeomInfo.primvarBinding.insert(
+      {HdTokens->transform, HdAnariTokens->transform});
+  mainGeomInfo.primvarBinding.insert({HdTokens->primID, HdAnariTokens->id});
+
+  for (auto primvarBinding : mainGeomInfo.primvarBinding) {
+    activePrimvars.push_back(primvarBinding.first);
+  }
+
+  // ...then geomsubsets.
+  GeomSubsetToInfo geomSubsetInfos;
+  GeomSubsetToSpecificPrimvarBindings geomSpecificPrimvarBindings;
+  for (auto subset : GetGeomSubsets(sceneDelegate, dirtyBits)) {
+    HdAnariMaterial *material = static_cast<HdAnariMaterial *>(
+        renderIndex.GetSprim(HdPrimTypeTokens->material, subset.materialId));
+    auto geomSubsetInfo = (material && material->GetAnariMaterial())
+        ? GeomSubsetInfo{material->GetAnariMaterial(),
+              material->GetPrimvarBinding()}
+        : GeomSubsetInfo{renderParam->GetDefaultMaterial(),
+              renderParam->GetDefaultPrimvarBinding()};
+
+    // Points and normals are implicit bindings
+    geomSubsetInfo.primvarBinding.insert(
+        {HdTokens->points, HdAnariTokens->position});
+    geomSubsetInfo.primvarBinding.insert(
+        {HdTokens->normals, HdAnariTokens->normal});
+
+    // Same with transforms and ids for instancing
+    geomSubsetInfo.primvarBinding.insert(
+        {HdTokens->transform, HdAnariTokens->transform});
+    geomSubsetInfo.primvarBinding.insert({HdTokens->primID, HdAnariTokens->id});
+
+    geomSubsetInfos.insert({subset.id, geomSubsetInfo});
+  }
+
+  // Add geomsubsets primvars to the set of active primvars. This set will be
+  // used to query primvars on the geometry and instancer.
+  for (auto geomSubsetInfo : geomSubsetInfos) {
+    for (auto primvarBinding : geomSubsetInfo.second.primvarBinding) {
+      activePrimvars.push_back(primvarBinding.first);
+    }
+  }
+
+  // Sort and uniqify.
+  std::sort(begin(activePrimvars), end(activePrimvars));
+  activePrimvars.erase(std::unique(begin(activePrimvars), end(activePrimvars)),
+      end(activePrimvars));
+
+  // Add points and normals to the set of active primvars if not there already.
+  for (auto primvar : {HdTokens->points, HdTokens->normals}) {
+    if (auto it = std::lower_bound(
+            cbegin(activePrimvars), cend(activePrimvars), primvar);
+        it != cend(activePrimvars)) {
+      if (*it != primvar)
+        activePrimvars.insert(it, primvar);
+    } else {
+      activePrimvars.push_back(primvar);
+    }
+  }
+
+  // List primvars to be removed and added.
+  auto previousPrimvars = std::vector<TfToken>();
+  for (auto primvarArray : primvarSource_) {
+    previousPrimvars.push_back(primvarArray.first);
+  }
+  std::sort(begin(previousPrimvars), end(previousPrimvars));
+
+  auto removedPrimvars = std::vector<TfToken>();
+  std::set_difference(cbegin(previousPrimvars),
+      cend(previousPrimvars),
+      cbegin(activePrimvars),
+      cend(activePrimvars),
+      back_inserter(removedPrimvars));
+
+  for (auto primvar : removedPrimvars) {
+    TF_DEBUG_MSG(
+        HD_ANARI_RD_GEOMETRY, "Removed primvar: %s", primvar.GetText());
+    auto it = primvarSource_.find(primvar);
+    if (std::holds_alternative<anari::Array1D>(it->second)) {
+      anari::release(device_, std::get<anari::Array1D>(it->second));
+    }
+    primvarSource_.erase(it);
+  }
+
+  // List new or updated primvars.
+  auto updatedPrimvars = std::vector<TfToken>();
+  std::set_difference(cbegin(activePrimvars),
+      cend(activePrimvars),
+      cbegin(removedPrimvars),
+      cend(removedPrimvars),
+      back_inserter(updatedPrimvars));
+  auto eraseIt = std::remove_if(
+      begin(updatedPrimvars), end(updatedPrimvars), [&](const auto &primvar) {
+        return !HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, primvar)
+            && (!instancer || !instancer->IsPrimvarDirty(primvar));
+      });
+  updatedPrimvars.erase(eraseIt, end(updatedPrimvars));
+  assert(std::is_sorted(cbegin(updatedPrimvars), cend(updatedPrimvars)));
+
+  // Release resources currently owned by updated primvars.
+  for (auto primvar : updatedPrimvars) {
+    TF_DEBUG_MSG(
+        HD_ANARI_RD_GEOMETRY, "Updated primvar: %s", primvar.GetText());
+    if (auto it = primvarSource_.find(primvar); it != end(primvarSource_)) {
+      if (std::holds_alternative<anari::Array1D>(it->second)) {
+        anari::release(device_, std::get<anari::Array1D>(it->second));
+      }
+      primvarSource_.erase(it);
+    }
+  }
+
+  // Based on the above, gather needed primvars descriptors. To be used to
+  // create primvars sources.
+  // Compute primvars have precedence over regular primvars.
+  auto computationPrimvarDescriptors =
+      HdExtComputationPrimvarDescriptorVector();
+  for (auto interpolation = 0; interpolation < HdInterpolationCount;
+      ++interpolation) {
+    if (interpolation == HdInterpolationInstance)
+      continue;
+
+    auto pvds = sceneDelegate->GetExtComputationPrimvarDescriptors(
+        GetId(), HdInterpolation(interpolation));
+    for (auto pvd : pvds) {
+      if (std::binary_search(
+              cbegin(updatedPrimvars), cend(updatedPrimvars), pvd.name)) {
+        computationPrimvarDescriptors.push_back(pvd);
       }
     }
   }
 
-  // Assume that points are always to be bound.
-  updatedPrimvarBinding.emplace(HdTokens->points, HdAnariTokens->position);
+  auto primvarDescriptors = HdPrimvarDescriptorVector();
+  for (auto interpolation = 0; interpolation < HdInterpolationCount;
+      ++interpolation) {
+    if (interpolation == HdInterpolationInstance)
+      continue;
 
-  // Gather computation primvars sources
+    auto pvds = sceneDelegate->GetPrimvarDescriptors(
+        GetId(), HdInterpolation(interpolation));
+    for (auto pvd : pvds) {
+      if (std::binary_search(
+              cbegin(updatedPrimvars), cend(updatedPrimvars), pvd.name)) {
+        primvarDescriptors.push_back(pvd);
+      }
+    }
+  }
+
+  // Get prim's compute value store.
   HdExtComputationUtils::ValueStore computationPrimvarSources =
       HdExtComputationUtils::GetComputedPrimvarValues(
           computationPrimvarDescriptors, sceneDelegate);
 
-  // Handle displayColor
-  if (auto it = updatedPrimvarBinding.find(HdTokens->displayColor);
-      it != std::cend(updatedPrimvarBinding)) {
-    if (!displayColorIsAuthored) {
-      _SetGeometryAttributeConstant(
-          it->second, VtValue(GfVec3f(0.8f, 0.8f, 0.8f)));
-    } else {
-      _SetGeometryAttributeConstant(it->second, VtValue());
-    }
-  }
-
-  // Handle shape specific changes
-  VtValue points;
+  // Create missing primvars. Might be needed for normals if smoothing is on
+  // for a mesh for instance.
+  VtVec3fArray points;
   if (auto it = computationPrimvarSources.find(HdTokens->points);
       it != std::cend(computationPrimvarSources)) {
-    points = it->second;
+    if (it->second.IsHolding<VtVec3fArray>())
+      points = it->second.UncheckedGet<VtVec3fArray>();
   }
 
-  if (!points.IsHolding<VtVec3fArray>() || points.GetArraySize() == 0) {
-    points = sceneDelegate->Get(id, HdTokens->points);
+  if (std::size(points) == 0) {
+    if (auto vtPoints = sceneDelegate->Get(id, HdTokens->points);
+        vtPoints.IsHolding<VtVec3fArray>())
+      points = vtPoints.UncheckedGet<VtVec3fArray>();
   }
 
-  for (const auto &additionalPrimvar :
-      UpdateGeometry(sceneDelegate, dirtyBits, allPrimvars, points)) {
-    updatedPrimvarBinding.insert(additionalPrimvar);
-  }
+  // Make sure we have all the information to do the actual parameter binding.
+  std::unordered_map<TfToken, HdInterpolation, TfToken::HashFunctor>
+      primvarInterpolation;
 
-  // Primvars
-  for (const auto &pvd : primvarDescriptors) {
-    if (auto pvbIt = updatedPrimvarBinding.find(pvd.name);
-        pvbIt != cend(updatedPrimvarBinding)) {
-      const auto &value = sceneDelegate->Get(id, pvd.name);
-      auto attributeName = pvbIt->second;
-      UpdatePrimvarSource(
-          sceneDelegate, pvd.interpolation, attributeName, value);
-    }
-  }
-
-  // Computation Primvars
-  for (const auto &pvd : computationPrimvarDescriptors) {
-    if (auto pvbIt = updatedPrimvarBinding.find(pvd.name);
-        pvbIt != cend(updatedPrimvarBinding)) {
+  // Create resources
+  {
+    for (auto pvd : computationPrimvarDescriptors) {
       const auto &valueIt = computationPrimvarSources.find(pvd.name);
       if (!TF_VERIFY(valueIt != std::cend(computationPrimvarSources)))
         continue;
-      const auto &value = valueIt->second;
-      auto attributeName = pvbIt->second;
-      UpdatePrimvarSource(
-          sceneDelegate, pvd.interpolation, attributeName, value);
+
+      // FIXME: What if an instance prim is a computation primvar. This cannot
+      // work with the actual implementation of GatherInstancePrimvar.
+      auto source = UpdatePrimvarSource(
+          sceneDelegate, pvd.interpolation, pvd.name, valueIt->second);
+
+      // The spot should always be free as it was removed if needed when
+      // processing primvar removal.
+      primvarSource_.insert({pvd.name, source});
+      primvarInterpolation.insert({pvd.name, pvd.interpolation});
+    }
+
+    for (auto pvd : primvarDescriptors) {
+      if (primvarSource_.count(pvd.name) != 0) {
+        continue;
+      }
+      auto source = UpdatePrimvarSource(sceneDelegate,
+          pvd.interpolation,
+          pvd.name,
+          sceneDelegate->Get(id, pvd.name));
+
+      primvarSource_.insert({pvd.name, source});
+      primvarInterpolation.insert({pvd.name, pvd.interpolation});
+    }
+
+    if (instancer) {
+      // Kind of a special handling here. Given that we don't have an explicit
+      // list of instance primvars, we need to gather them here, based on
+      // updated primvars
+      for (auto primvar : updatedPrimvars) {
+        // If a geometry based primvar exists, let it take precedence over the
+        // instance primvar.
+        if (primvarSource_.count(primvar) != 0) {
+          continue;
+        }
+
+        auto value = instancer->GatherInstancePrimvar(GetId(), primvar);
+        if (value.IsArrayValued()) {
+          primvarSource_.insert({primvar, _GetAttributeArray(value)});
+          primvarInterpolation.insert({primvar, HdInterpolationInstance});
+        }
+      }
     }
   }
 
-  anari::commitParameters(_anari.device, _anari.geometry);
-
-  if (HdChangeTracker::IsDirty(HdChangeTracker::DirtyPrimID)) {
-    anari::setParameter(
-        _anari.device, _anari.surface, "id", uint32_t(GetPrimId()));
-    anari::commitParameters(_anari.device, _anari.surface);
-  }
-
-  // Now with this instancing
-  // Populate instance objects.
-
-  // Transforms //
-  if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)
-      || HdChangeTracker::IsInstancerDirty(*dirtyBits, id)
-      || HdChangeTracker::IsInstanceIndexDirty(*dirtyBits, id)) {
-    auto baseTransform = sceneDelegate->GetTransform(id);
-
-    // Set instance parameters
-    if (GetInstancerId().IsEmpty()) {
-#if USE_INSTANCE_ARRAYS
-      anari::setParameter(_anari.device,
-          _anari.instance,
-          "transform",
-          GfMatrix4f(baseTransform));
-      anari::setParameter(_anari.device, _anari.instance, "id", 0u);
-#else
-      transforms_UNIQUE_INSTANCES_.push_back(GfMatrix4f(baseTransform));
-      ids_UNIQUE_INSTANCES_.push_back(0);
-#endif
-    } else {
-      auto instancer = static_cast<HdAnariInstancer *>(
-          renderIndex.GetInstancer(GetInstancerId()));
+  // Create instance related variables
+  if (instancer) {
+    // FIXME: Those transformed are shared between all prims under the same
+    // instancer hierarchy and yet we recompute those per prim. This should be
+    // cached at the instancer level and returned as anari::Array1D.
+    if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)
+        || HdChangeTracker::IsInstanceIndexDirty(*dirtyBits, id)
+        || HdChangeTracker::IsInstancerDirty(*dirtyBits, id)) {
+      auto baseTransform = sceneDelegate->GetTransform(id);
 
       // Transforms
       const VtMatrix4dArray &transformsd =
@@ -410,133 +665,249 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
           [&baseTransform](
               const auto &tx) { return GfMatrix4f(baseTransform * tx); });
 
+      auto transformsArray =
+          anari::newArray1D(device_, ANARI_FLOAT32_MAT4, std::size(transforms));
+      {
+        auto ptr = anari::map<void>(device_, transformsArray);
+        std::memcpy(ptr,
+            std::data(transforms),
+            std::size(transforms) * anari::sizeOf(ANARI_FLOAT32_MAT4));
+        anari::unmap(device_, transformsArray);
+      }
+
+      auto transformsArrayIt = primvarSource_.find(HdTokens->transform);
+      if (transformsArrayIt == end(primvarSource_)) {
+        primvarSource_.insert(
+            transformsArrayIt, {HdTokens->transform, transformsArray});
+      } else {
+        anari::release(
+            device_, std::get<anari::Array1D>(transformsArrayIt->second));
+        transformsArrayIt->second = transformsArray;
+      }
+      updatedPrimvars.push_back(HdTokens->transform);
+      primvarInterpolation.insert(
+          {HdTokens->transform, HdInterpolationInstance});
+
       VtUIntArray ids(transforms.size());
       std::iota(std::begin(ids), std::end(ids), 0);
 
-#if USE_INSTANCE_ARRAYS
-      _SetInstanceAttributeArray(HdAnariTokens->transform, VtValue(transforms));
-      _SetInstanceAttributeArray(HdAnariTokens->id, VtValue(ids));
-#else
-      transforms_UNIQUE_INSTANCES_ = std::move(transforms);
-      ids_UNIQUE_INSTANCES_ = std::move(ids);
-#endif
+      auto idsArray = anari::newArray1D(device_, ANARI_UINT32, std::size(ids));
+      {
+        auto ptr = anari::map<void>(device_, idsArray);
+        std::memcpy(
+            ptr, std::data(ids), std::size(ids) * anari::sizeOf(ANARI_UINT32));
+        anari::unmap(device_, idsArray);
+      }
+      auto idsArrayIt = primvarSource_.find(HdTokens->primID);
+      if (idsArrayIt == end(primvarSource_)) {
+        primvarSource_.insert(idsArrayIt, {HdTokens->primID, idsArray});
+      } else {
+        anari::release(device_, std::get<anari::Array1D>(idsArrayIt->second));
+        idsArrayIt->second = idsArray;
+      }
+      updatedPrimvars.push_back(HdTokens->primID);
+      primvarInterpolation.insert({HdTokens->primID, HdInterpolationInstance});
     }
   }
 
-  // Primvars
-  if (HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, id)
-      || HdChangeTracker::IsInstancerDirty(*dirtyBits, id)
-      || HdChangeTracker::IsInstanceIndexDirty(*dirtyBits, id)) {
-    auto instancer = static_cast<HdAnariInstancer *>(
-        renderIndex.GetInstancer(GetInstancerId()));
+  // Handle anari objects creation
+  std::vector<anari::Instance> instances;
+  if (geomSubsetInfos.empty()) {
+    //  Use main geom is no subset is defined.
+    geomSubsetInfos.insert({GetId(), mainGeomInfo});
+  }
 
-    // Process primvars
-    HdPrimvarDescriptorVector instancePrimvarDescriptors;
-    for (auto instancerId = GetInstancerId(); !instancerId.IsEmpty();
-         instancerId = renderIndex.GetInstancer(instancerId)->GetParentId()) {
-      for (const auto &pv : sceneDelegate->GetPrimvarDescriptors(
-               instancerId, HdInterpolationInstance)) {
-        if (pv.name == HdInstancerTokens->instanceRotations
-            || pv.name == HdInstancerTokens->instanceScales
-            || pv.name == HdInstancerTokens->instanceTranslations
-            || pv.name == HdInstancerTokens->instanceTransforms)
-          continue;
+  // Release geomsubset that are not used anymore.
+  for (auto it = geomSubsetGeometry_.begin();
+      it != geomSubsetGeometry_.end();) {
+    if (geomSubsetInfos.count(it->first) == 0) {
+      anari::release(device_, it->second.geometry);
+      anari::release(device_, it->second.surface);
+      anari::release(device_, it->second.group);
+      anari::release(device_, it->second.instance);
+      it = geomSubsetGeometry_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 
-        if (allPrimvars.find(pv.name) != std::cend(allPrimvars))
-          continue;
-        allPrimvars.insert(pv.name);
+  // Traverse all the subset (including prim's main geometry) and build related
+  // anari objects.
+  for (auto &&[subsetId, geomInfo] : geomSubsetInfos) {
+    auto &geometryDesc = geomSubsetGeometry_[subsetId];
 
-        // Consider the primvar if it is dirty and is part of the new binding
-        // set
-        TfToken prevBindingPoint;
-        TfToken newBindingPoint;
-        if (auto it = previousBinding.find(pv.name);
-            it != std::cend(previousBinding))
-          prevBindingPoint = it->second;
-        if (auto it = updatedPrimvarBinding.find(pv.name);
-            it != std::cend(updatedPrimvarBinding))
-          newBindingPoint = it->second;
+    PrimvarStateDesc removedState;
+    PrimvarStateDesc updatedState;
+    HdAnariMaterial::PrimvarBinding newPrimvarsBinding =
+        geomInfo.primvarBinding;
+    HdAnariMaterial::PrimvarBinding previousPrimvarsBinding = {};
 
-        auto thisInstancer = static_cast<const HdAnariInstancer *>(
-            renderIndex.GetInstancer(instancerId));
+    if (!geometryDesc.instance) {
+      geometryDesc.geometry =
+          anari::newObject<anari::Geometry>(device_, geometryType_.GetText());
 
-        if (prevBindingPoint != newBindingPoint
-            || thisInstancer->IsPrimvarDirty(pv.name)) {
-          instancePrimvarDescriptors.push_back(pv);
+      geometryDesc.surface = anari::newObject<anari::Surface>(device_);
+      anari::setParameter(
+          device_, geometryDesc.surface, "geometry", geometryDesc.geometry);
+      anari::setParameter(
+          device_, geometryDesc.surface, "id", uint32_t(GetPrimId()));
+      anari::setParameter(
+          device_, geometryDesc.surface, "material", geomInfo.material);
+      anari::commitParameters(device_, geometryDesc.surface);
+
+      geometryDesc.group = anari::newObject<anari::Group>(device_);
+      std::array<anari::Surface, 1> surfaces{geometryDesc.surface};
+      anari::setParameterArray1D(device_,
+          geometryDesc.group,
+          "surface",
+          data(surfaces),
+          size(surfaces));
+      anari::commitParameters(device_, geometryDesc.group);
+
+      geometryDesc.instance =
+          anari::newObject<anari::Instance>(device_, "transform");
+      auto baseTransform = sceneDelegate->GetTransform(GetId());
+      anari::setParameter(device_,
+          geometryDesc.instance,
+          "transform",
+          GfMatrix4f(baseTransform));
+      anari::setParameter(device_, geometryDesc.instance, "id", 0u);
+      anari::setParameter(
+          device_, geometryDesc.instance, "group", geometryDesc.group);
+      anari::commitParameters(device_, geometryDesc.instance);
+
+      // First time, everything is new
+      updatedState = {
+          activePrimvars,
+          primvarInterpolation,
+      };
+      newPrimvarsBinding = geomInfo.primvarBinding;
+    } else {
+      // Update
+      removedState = {
+          removedPrimvars,
+          primvarInterpolation_,
+      };
+      updatedState = {
+          updatedPrimvars,
+          primvarInterpolation,
+      };
+
+      previousPrimvarsBinding = mainGeomInfo_.primvarBinding;
+      newPrimvarsBinding = mainGeomInfo.primvarBinding;
+    }
+
+    // FIXME: Do the same with displayOpacity and maybe others...
+    if (displayColorIsAuthored) {
+      // Make sure any previous default display color is removed so the actual
+      // authored one is used.
+      if (std::binary_search(cbegin(updatedPrimvars),
+              cend(updatedPrimvars),
+              HdTokens->displayColor)) {
+        // Clear the constant value so any other can be used instead
+        if (auto it = previousPrimvarsBinding.find(HdTokens->displayColor);
+            it != cend(previousPrimvarsBinding)) {
+          anari::unsetParameter(
+              device_, geometryDesc.geometry, it->second.GetText());
         }
       }
-    }
-
-    for (const auto &pv : instancePrimvarDescriptors) {
-      if (auto it = updatedPrimvarBinding.find(pv.name);
-          it != std::cend(updatedPrimvarBinding)) {
-#if USE_INSTANCE_ARRAYS
-        _SetInstanceAttributeArray(
-            it->second, instancer->GatherInstancePrimvar(GetId(), pv.name));
-#else
-        instancedPrimvar_UNIQUE_INSTANCES_.emplace_back(
-            it->second, instancer->GatherInstancePrimvar(GetId(), pv.name));
-#endif
+    } else {
+      // If the material depends on displayColor, make sure we handle the case
+      // it is not authored.
+      if (auto it = newPrimvarsBinding.find(HdTokens->displayColor);
+          it != cend(newPrimvarsBinding)) {
+        anari::setParameter(device_,
+            geometryDesc.geometry,
+            it->second.GetText(),
+            GfVec4f(0.8f, 0.8f, 0.8f, 1.0f));
       }
     }
-  }
+    // Apply the changes to the geometry object
+    SyncAnariGeometry(device_,
+        geometryDesc.geometry,
+        primvarSource_,
+        newPrimvarsBinding,
+        previousPrimvarsBinding,
 
-#if USE_INSTANCE_ARRAYS
-  anari::commitParameters(_anari.device, _anari.instance);
-#else
-  ReleaseInstances();
-  _anari.instances.reserve(std::size(transforms_UNIQUE_INSTANCES_));
+        updatedState,
+        removedState);
 
-  for (auto i = 0ul; i < std::size(transforms_UNIQUE_INSTANCES_); ++i) {
-    auto instance =
-        anari::newObject<anari::Instance>(_anari.device, "transform");
-    anari::setParameter(_anari.device, instance, "group", _anari.group);
-    anari::setParameter(
-        _anari.device, instance, "transform", transforms_UNIQUE_INSTANCES_[i]);
-    anari::setParameter(
-        _anari.device, instance, "id", ids_UNIQUE_INSTANCES_[i]);
+    // We do try and get them at each sync, as it is not clear when those are
+    // dirtied. The expectation is that the implementation of
+    // GetGeomSpecificPrimvars is doing the caching.
+    auto geomSpecificBindingPoints = GetGeomSpecificPrimvars(sceneDelegate,
+        dirtyBits,
+        TfToken::Set(cbegin(allPrimvars), cend(allPrimvars)),
+        points,
+        subsetId);
 
-    for (auto &&[attr, value] : instancedPrimvar_UNIQUE_INSTANCES_) {
-      if (value.IsHolding<VtFloatArray>()) {
-        const auto &array = value.UncheckedGet<VtFloatArray>();
-        if (i < std::size(array))
-          anari::setParameter(
-              _anari.device, instance, attr.GetText(), array[i]);
-      } else if (value.IsHolding<VtVec2fArray>()) {
-        const auto &array = value.UncheckedGet<VtVec2fArray>();
-        if (i < std::size(array))
-          anari::setParameter(
-              _anari.device, instance, attr.GetText(), array[i]);
-      } else if (value.IsHolding<VtVec3fArray>()) {
-        const auto &array = value.UncheckedGet<VtVec3fArray>();
-        if (i < std::size(array))
-          anari::setParameter(
-              _anari.device, instance, attr.GetText(), array[i]);
-      } else if (value.IsHolding<VtVec4fArray>()) {
-        const auto &array = value.UncheckedGet<VtVec4fArray>();
-        if (i < std::size(array))
-          anari::setParameter(
-              _anari.device, instance, attr.GetText(), array[i]);
-      }
+    for (auto &&[bindingPoint, array] : geomSpecificBindingPoints) {
+      geomSpecificPrimvarBindings[subsetId].push_back(bindingPoint);
+      anari::setParameter(
+          device_, geometryDesc.geometry, bindingPoint.GetText(), array);
     }
-    anari::commitParameters(_anari.device, instance);
-    _anari.instances.push_back(instance);
+
+    // Clear geomspecfic binding points set by previous sync that are no more
+    // used.
+    std::vector<TfToken> geomSpecificRemovedBindings;
+    std::set_difference(cbegin(geomSpecificPrimvarBindings_[subsetId]),
+        cend(geomSpecificPrimvarBindings_[subsetId]),
+        cbegin(geomSpecificPrimvarBindings[subsetId]),
+        cend(geomSpecificPrimvarBindings[subsetId]),
+        back_inserter(geomSpecificRemovedBindings));
+
+    for (const auto &bindingPoint : geomSpecificRemovedBindings) {
+      anari::unsetParameter(
+          device_, geometryDesc.geometry, bindingPoint.GetText());
+    }
+
+    anari::commitParameters(device_, geometryDesc.geometry);
+
+    // Material update
+    if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
+      anari::setParameter(
+          device_, geometryDesc.surface, "material", geomInfo.material);
+    }
+    anari::commitParameters(device_, geometryDesc.surface);
+
+    // Instance update
+    if (instancer) {
+      SyncAnariInstance(device_,
+          geometryDesc.instance,
+          primvarSource_,
+          newPrimvarsBinding,
+          previousPrimvarsBinding,
+
+          updatedState,
+          removedState);
+    } else {
+      auto baseTransform = sceneDelegate->GetTransform(GetId());
+      anari::setParameter(device_,
+          geometryDesc.instance,
+          "transform",
+          GfMatrix4f(baseTransform));
+      anari::setParameter(device_, geometryDesc.instance, "id", 0u);
+    }
+
+    anari::commitParameters(device_, geometryDesc.instance);
+    instances.push_back(geometryDesc.instance);
   }
-
-  renderParam->MarkNewSceneVersion();
-#endif
-
-  primvarBinding_ = updatedPrimvarBinding;
 
   if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
     _UpdateVisibility(sceneDelegate, dirtyBits);
-    // renderParam->MarkNewSceneVersion();
+    renderParam->MarkNewSceneVersion();
   }
 
   if (!_populated) {
     renderParam->RegisterGeometry(this);
     _populated = true;
   }
+
+  instances_ = instances;
+
+  geomSubsetInfo_ = std::move(geomSubsetInfos);
+  primvarInterpolation_ = std::move(primvarInterpolation);
+  geomSpecificPrimvarBindings_ = std::move(geomSpecificPrimvarBindings);
 
   *dirtyBits &= ~HdChangeTracker::AllSceneDirtyBits;
 }
@@ -545,13 +916,7 @@ void HdAnariGeometry::GatherInstances(
     std::vector<anari::Instance> &instances) const
 {
   if (IsVisible()) {
-#if USE_INSTANCE_ARRAYS
-    instances.push_back(_anari.instance);
-#else
-    std::copy(std::cbegin(_anari.instances),
-        std::cend(_anari.instances),
-        std::back_inserter(instances));
-#endif
+    std::copy(cbegin(instances_), cend(instances_), back_inserter(instances));
   }
 }
 
@@ -561,6 +926,21 @@ void HdAnariGeometry::Finalize(HdRenderParam *renderParam_)
     auto *renderParam = static_cast<HdAnariRenderParam *>(renderParam_);
     renderParam->UnregisterGeometry(this);
     _populated = false;
+  }
+
+  // Release geometry
+  for (auto &&[_, geometryDesc] : geomSubsetGeometry_) {
+    anari::release(device_, geometryDesc.geometry);
+    anari::release(device_, geometryDesc.surface);
+    anari::release(device_, geometryDesc.group);
+    anari::release(device_, geometryDesc.instance);
+  }
+
+  // Release primvar sources
+  for (const auto &primvarSource : primvarSource_) {
+    if (std::holds_alternative<anari::Array1D>(primvarSource.second)) {
+      anari::release(device_, std::get<anari::Array1D>(primvarSource.second));
+    }
   }
 }
 
@@ -582,115 +962,55 @@ void HdAnariGeometry::_InitRepr(
   }
 }
 
-#if !USE_INSTANCE_ARRAYS
-void HdAnariGeometry::ReleaseInstances()
-{
-  for (const auto &instance : _anari.instances) {
-    anari::release(_anari.device, instance);
-  }
-  _anari.instances.clear();
-}
-#endif
-
-void HdAnariGeometry::_SetGeometryAttributeConstant(
-    const TfToken &attributeName, const VtValue &value)
-{
-  auto d = _anari.device;
-  auto g = _anari.geometry;
-
-  GfVec4f attrV(0.f, 0.f, 0.f, 1.f);
-  if (_GetVtValueAsAttribute(value, attrV)) {
-    anari::setParameter(d, g, attributeName.GetText(), attrV);
-    geometryBindingPoints_.emplace(attributeName, attributeName);
-    TF_DEBUG_MSG(HD_ANARI_RD_GEOMETRY,
-        "Assigning constant %s to mesh %s\n",
-        attributeName.GetText(),
-        GetId().GetText());
-  } else {
-    if (auto it = geometryBindingPoints_.find(attributeName);
-        it != std::end(geometryBindingPoints_)) {
-      geometryBindingPoints_.erase(it);
-      TF_DEBUG_MSG(HD_ANARI_RD_GEOMETRY,
-          "Clearing constant %s on mesh %s\n",
-          attributeName.GetText(),
-          GetId().GetText());
-      anari::unsetParameter(d, g, attributeName.GetText());
-    }
-  }
-}
-
-void HdAnariGeometry::_SetGeometryAttributeArray(const TfToken &attributeName,
-    const TfToken &bindingPoint,
-    const VtValue &value,
-    anari::DataType forcedType)
+anari::Array1D HdAnariGeometry::_GetAttributeArray(
+    const VtValue &value, anari::DataType overrideType)
 {
   anari::DataType type = ANARI_UNKNOWN;
   const void *data = nullptr;
   size_t size = 0;
 
-  if (!value.IsEmpty() && _GetVtArrayBufferData(value, &data, &size, &type)) {
-    TF_DEBUG_MSG(HD_ANARI_RD_GEOMETRY,
-        "Assigning geometry primvar %s to %s on mesh %s\n",
-        attributeName.GetText(),
-        bindingPoint.GetText(),
-        GetId().GetText());
-    anari::setParameterArray1D(_anari.device,
-        _anari.geometry,
-        bindingPoint.GetText(),
-        forcedType == ANARI_UNKNOWN ? type : forcedType,
-        data,
-        size);
-    geometryBindingPoints_.emplace(attributeName, attributeName);
-  } else {
-    if (auto it = geometryBindingPoints_.find(attributeName);
-        it != std::end(geometryBindingPoints_)) {
-      geometryBindingPoints_.erase(it);
-      anari::unsetParameter(
-          _anari.device, _anari.geometry, bindingPoint.GetText());
-      TF_DEBUG_MSG(HD_ANARI_RD_GEOMETRY,
-          "Clearing geometry primvar %s on %s on mesh %s\n",
-          attributeName.GetText(),
-          bindingPoint.GetText(),
-          GetId().GetText());
-    }
+  if (!value.IsEmpty() && _GetVtArrayBufferData(value, &data, &size, &type)
+      && size) {
+    // Don't assume any ownership of the data. Map can copy asap.
+    if (overrideType != ANARI_UNKNOWN)
+      type = overrideType;
+    auto array = anari::newArray1D(device_, type, size);
+    auto ptr = anari::map<void>(device_, array);
+    std::memcpy(ptr, data, size * anari::sizeOf(type));
+    anari::unmap(device_, array);
+    return array;
   }
+
+  TF_RUNTIME_ERROR("Cannot extract value buffer from VtValue");
+  return {};
 }
 
-#if USE_INSTANCE_ARRAYS
-void HdAnariGeometry::_SetInstanceAttributeArray(const TfToken &attributeName,
-    const VtValue &value,
-    anari::DataType forcedType)
+TfToken HdAnariGeometry::_GetBindingPoint(
+    const TfToken &token, HdInterpolation interpolation)
 {
-  anari::DataType type = ANARI_UNKNOWN;
-  const void *data = nullptr;
-  size_t size = 0;
-
-  if (!value.IsEmpty() && _GetVtArrayBufferData(value, &data, &size, &type)) {
-    TF_DEBUG_MSG(HD_ANARI_RD_GEOMETRY,
-        "Assigning instance primvar %s to mesh %s\n",
-        attributeName.GetText(),
-        GetId().GetText());
-    anari::setParameterArray1D(_anari.device,
-        _anari.instance,
-        attributeName.GetText(),
-        forcedType == ANARI_UNKNOWN ? type : forcedType,
-        data,
-        size);
-    instanceBindingPoints_.emplace(attributeName, attributeName);
-  } else {
-    if (auto it = instanceBindingPoints_.find(attributeName);
-        it != std::end(instanceBindingPoints_)) {
-      instanceBindingPoints_.erase(it);
-      anari::unsetParameter(
-          _anari.device, _anari.instance, attributeName.GetText());
-      TF_DEBUG_MSG(HD_ANARI_RD_GEOMETRY,
-          "Clearing instance primvar %s on mesh %s\n",
-          attributeName.GetText(),
-          GetId().GetText());
-    }
+  switch (interpolation) {
+  case HdInterpolationConstant: {
+    return token;
   }
+  case HdInterpolationUniform: {
+    return _GetPrimitiveBindingPoint(token);
+  }
+  case HdInterpolationVarying:
+  case HdInterpolationVertex: {
+    return _GetVertexBindingPoint(token);
+  }
+  case HdInterpolationFaceVarying: {
+    return _GetFaceVaryingBindingPoint(token);
+  }
+  case HdInterpolationInstance: {
+    return token;
+  }
+  case HdInterpolationCount:
+    assert(false);
+  }
+
+  return {};
 }
-#endif
 
 TfToken HdAnariGeometry::_GetPrimitiveBindingPoint(const TfToken &attribute)
 {

--- a/src/hdanari/geometry.h
+++ b/src/hdanari/geometry.h
@@ -3,14 +3,20 @@
 
 #pragma once
 
+#include "material.h"
+
+// anari
+#include <anari/frontend/anari_enums.h>
 #include <anari/anari_cpp.hpp>
 // pxr
+#include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
 #include <pxr/base/vt/types.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/enums.h>
 #include <pxr/imaging/hd/extComputationUtils.h>
+#include <pxr/imaging/hd/geomSubset.h>
 #include <pxr/imaging/hd/mesh.h>
 #include <pxr/imaging/hd/meshTopology.h>
 #include <pxr/imaging/hd/meshUtil.h>
@@ -22,14 +28,11 @@
 #include <pxr/imaging/hf/perfLog.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
-#include <map>
 // std
-#include <memory>
-#include <optional>
+#include <cstddef>
+#include <unordered_map>
+#include <variant>
 #include <vector>
-
-#include "material.h"
-#include "meshUtil.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -58,72 +61,147 @@ class HdAnariGeometry : public HdMesh
   HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
 
  protected:
-  virtual HdAnariMaterial::PrimvarBinding UpdateGeometry(
+  // Used to handle shape specific (as in non material) primvars.
+  // For instance normals for meshs or radius for points.
+  struct GeomSpecificPrimVar
+  {
+    TfToken bindingPoint;
+    anari::Array1D array;
+  };
+  using GeomSpecificPrimvars = std::vector<GeomSpecificPrimVar>;
+
+  virtual GeomSpecificPrimvars GetGeomSpecificPrimvars(
       HdSceneDelegate *sceneDelegate,
       HdDirtyBits *dirtyBits,
       const TfToken::Set &allPrimvars,
-      const VtValue &points) = 0;
-  virtual void UpdatePrimvarSource(HdSceneDelegate *sceneDelegate,
+      const VtVec3fArray &points,
+      const SdfPath &geomsetId = {})
+  {
+    return {};
+  };
+
+  // Store the actual value of a primvar source.
+  using PrimvarSource = std::variant<std::monostate, GfVec4f, anari::Array1D>;
+  // Shape specific creation of a primvar source based on its value and
+  // interpolation. This is used to create the actual constant or
+  // anari::Array1D.
+  virtual PrimvarSource UpdatePrimvarSource(HdSceneDelegate *sceneDelegate,
       HdInterpolation interpolation,
       const TfToken &attributeName,
       const VtValue &value) = 0;
 
-  TfToken _GetPrimitiveBindingPoint(const TfToken &attribute);
-  TfToken _GetFaceVaryingBindingPoint(const TfToken &attribute);
-  TfToken _GetVertexBindingPoint(const TfToken &attribute);
+  // Helper functions returning anari attribute name based on the given
+  // HdInterpolation.
+  static TfToken _GetBindingPoint(
+      const TfToken &token, HdInterpolation interpolation);
 
-  void _SetGeometryAttributeConstant(
-      const TfToken &attributeName, const VtValue &v);
-  void _SetGeometryAttributeArray(const TfToken &attributeName,
-      const TfToken &bindingPoint,
-      const VtValue &v,
-      anari::DataType forcedType = ANARI_UNKNOWN);
-#if USE_INSTANCE_ARRAYS
-  void _SetInstanceAttributeArray(const TfToken &attributeName,
-      const VtValue &v,
-      anari::DataType forcedType = ANARI_UNKNOWN);
-#endif
+  static TfToken _GetPrimitiveBindingPoint(const TfToken &attribute);
+  static TfToken _GetFaceVaryingBindingPoint(const TfToken &attribute);
+  static TfToken _GetVertexBindingPoint(const TfToken &attribute);
+
+  // Creates an array out of the given VtValue.
+  anari::Array1D _GetAttributeArray(
+      const VtValue &v, anari::DataType forcedType = ANARI_UNKNOWN);
 
   void _InitRepr(const TfToken &reprToken, HdDirtyBits *dirtyBits) override;
 
-#if !USE_INSTANCE_ARRAYS
-  void ReleaseInstances();
-#endif
+  // More helper  function to extract data from VtValue.
+  static bool _GetVtValueAsAttribute(VtValue v, GfVec4f &out);
+  static bool _GetVtArrayBufferData(
+      VtValue v, const void **data, size_t *size, anari::DataType *type);
 
   HdAnariGeometry(const HdAnariGeometry &) = delete;
   HdAnariGeometry &operator=(const HdAnariGeometry &) = delete;
 
+  // Returns the shape geomsubsets.
+  virtual HdGeomSubsets GetGeomSubsets(
+      HdSceneDelegate *sceneDelegate, HdDirtyBits *dirtyBits)
+  {
+    return {};
+  }
+
  private:
   // Data //
   bool _populated{false};
-  HdMeshTopology topology_;
-  std::unique_ptr<HdAnariMeshUtil> meshUtil_;
-  std::optional<Hd_VertexAdjacency> adjacency_;
+  // The anari geometry type.
+  TfToken geometryType_;
 
-  VtIntArray trianglePrimitiveParams_;
-
-  HdAnariMaterial::PrimvarBinding primvarBinding_;
-  std::map<TfToken, TfToken> geometryBindingPoints_;
-  std::map<TfToken, TfToken> instanceBindingPoints_;
-
-#if !USE_INSTANCE_ARRAYS
-  VtMatrix4fArray transforms_UNIQUE_INSTANCES_;
-  VtUIntArray ids_UNIQUE_INSTANCES_;
-  std::vector<std::pair<TfToken, VtValue>> instancedPrimvar_UNIQUE_INSTANCES_;
-#endif
-
-  struct AnariObjects
+  // Stores material and related primvar binndings for a given geomsubset.
+  struct GeomSubsetInfo
   {
-    anari::Device device{nullptr};
-    anari::Geometry geometry{nullptr};
-    anari::Surface surface{nullptr};
-    anari::Group group{nullptr};
-#if USE_INSTANCE_ARRAYS
-    anari::Instance instance{nullptr};
-#else
-    std::vector<anari::Instance> instances;
-#endif
-  } _anari;
+    anari::Material material;
+    HdAnariMaterial::PrimvarBinding primvarBinding;
+  };
+  // main and geomsubset infos.
+  GeomSubsetInfo mainGeomInfo_;
+  using GeomSubsetToInfo =
+      std::unordered_map<SdfPath, GeomSubsetInfo, SdfPath::Hash>;
+  GeomSubsetToInfo geomSubsetInfo_;
+
+  // Primvar source cache
+  using PrimvarToSource =
+      std::unordered_map<TfToken, PrimvarSource, TfToken::HashFunctor>;
+  using PrimvarToInterpolation =
+      std::unordered_map<TfToken, HdInterpolation, TfToken::HashFunctor>;
+
+  // Keep track of which primvars are known, their bindings and interpolation
+  PrimvarToSource primvarSource_;
+  PrimvarToInterpolation primvarInterpolation_;
+  HdAnariMaterial::PrimvarBinding primvarBindings_;
+
+  // Same with geometry specific primvars
+  using GeomSpecificPrimvarBindings = TfTokenVector;
+  using GeomSubsetToSpecificPrimvarBindings =
+      std::unordered_map<SdfPath, GeomSpecificPrimvarBindings, SdfPath::Hash>;
+  GeomSubsetToSpecificPrimvarBindings geomSpecificPrimvarBindings_;
+
+  // Anari objects for a geomsubset
+  struct AnariInstanceDesc
+  {
+    anari::Geometry geometry{};
+    anari::Surface surface{};
+    anari::Group group{};
+    anari::Instance instance{};
+  };
+
+  using GeomSubsetToAnariInstanceDesc =
+      std::unordered_map<SdfPath, AnariInstanceDesc, SdfPath::Hash>;
+  GeomSubsetToAnariInstanceDesc geomSubsetGeometry_;
+
+ protected:
+  anari::Device device_{nullptr};
+  std::vector<anari::Instance> instances_;
+
+  // Stores the state of primvars and their interpolation.
+  // Used to handle removal and additon of primvars compared to previous sync.
+  struct PrimvarStateDesc
+  {
+    std::vector<TfToken> primvars;
+    std::unordered_map<TfToken, HdInterpolation, TfToken::HashFunctor>
+        primvarsInterpolation;
+  };
+
+  // Handles updating a single anari goemetry.
+  static void SyncAnariGeometry(anari::Device device,
+      anari::Geometry geometry,
+
+      const PrimvarToSource &primvarSources,
+      HdAnariMaterial::PrimvarBinding updatedPrimvarsBinding,
+      HdAnariMaterial::PrimvarBinding previousPrimvarsBinding,
+
+      const PrimvarStateDesc &updates,
+      const PrimvarStateDesc &removes);
+
+  // Handles updating a single anari instance.
+  static void SyncAnariInstance(anari::Device device,
+      anari::Instance instance,
+
+      const PrimvarToSource &primvarSources,
+      HdAnariMaterial::PrimvarBinding updatedPrimvarsBinding,
+      HdAnariMaterial::PrimvarBinding previousPrimvarsBinding,
+
+      const PrimvarStateDesc &updates,
+      const PrimvarStateDesc &removes);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/instancer.cpp
+++ b/src/hdanari/instancer.cpp
@@ -3,6 +3,10 @@
 
 #include "instancer.h"
 
+#include "debugCodes.h"
+#include "sampler.h"
+
+// pxr
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/quatd.h>
 #include <pxr/base/gf/quath.h>
@@ -25,23 +29,20 @@
 #include <pxr/imaging/hd/enums.h>
 #include <pxr/imaging/hd/instancer.h>
 #include <pxr/imaging/hd/perfLog.h>
-#include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/types.h>
 #include <pxr/imaging/hd/vtBufferSource.h>
 #include <pxr/imaging/hf/perfLog.h>
-#include <stddef.h>
+#include <pxr/usd/sdf/path.h>
+// std
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
-#include <memory>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include "debugCodes.h"
-#include "sampler.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -338,10 +339,10 @@ VtValue HdAnariInstancer::GatherInstancePrimvar(
     dataType = it->second->GetTupleType().type;
   } else {
     for (auto instancerId = GetParentId(); !instancerId.IsEmpty();
-         instancerId = GetDelegate()
-                           ->GetRenderIndex()
-                           .GetInstancer(instancerId)
-                           ->GetParentId()) {
+        instancerId = GetDelegate()
+            ->GetRenderIndex()
+            .GetInstancer(instancerId)
+            ->GetParentId()) {
       auto instancer = static_cast<const HdAnariInstancer *>(
           GetDelegate()->GetRenderIndex().GetInstancer(instancerId));
       if (auto it = instancer->_primvarMap.find(primvarName);
@@ -376,6 +377,9 @@ VtValue HdAnariInstancer::GatherInstancePrimvar(
     break;
   case HdTypeDoubleVec4:
     return GatherInstancePrimvar<GfVec4d>(prototypeId, primvarName, dataType);
+    break;
+  case HdTypeInvalid:
+    // Invalid means we did not find a matching primvar.
     break;
   default:
     TF_CODING_ERROR("Unsupported primvar type for instance gathering [%s.%s]",

--- a/src/hdanari/mesh.cpp
+++ b/src/hdanari/mesh.cpp
@@ -3,8 +3,17 @@
 
 #include "mesh.h"
 
+#include "anariTokens.h"
+#include "geometry.h"
+#include "renderParam.h"
+// anari
+#include <anari/anari.h>
 #include <anari/frontend/anari_enums.h>
-#include <pxr/base/tf/debug.h>
+#include <anari/anari_cpp.hpp>
+#include <anari/anari_cpp/anari_cpp_impl.hpp>
+// pxr
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
@@ -13,18 +22,21 @@
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/changeTracker.h>
 #include <pxr/imaging/hd/enums.h>
+#include <pxr/imaging/hd/geomSubset.h>
+#include <pxr/imaging/hd/meshUtil.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/smoothNormals.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/types.h>
 #include <pxr/imaging/hd/vtBufferSource.h>
-
-#include <anari/anari_cpp.hpp>
+#include <pxr/imaging/pxOsd/tokens.h>
+// std
+#include <cassert>
 #include <iterator>
-
-#include "anariTokens.h"
-#include "debugCodes.h"
-#include "geometry.h"
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace std::string_literals;
 
@@ -50,46 +62,129 @@ HdDirtyBits HdAnariMesh::GetInitialDirtyBitsMask() const
       | HdChangeTracker::DirtyRepr | HdChangeTracker::DirtyMaterialId;
 }
 
-HdAnariMaterial::PrimvarBinding HdAnariMesh::UpdateGeometry(
-    HdSceneDelegate *sceneDelegate,
+void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
+    HdRenderParam *renderParam_,
     HdDirtyBits *dirtyBits,
-    const TfToken::Set &allPrimvars,
-    const VtValue &points)
+    const TfToken &reprToken)
 {
-  // Triangle indices //
+  auto renderParam = static_cast<HdAnariRenderParam *>(renderParam_);
+
   if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())) {
+    auto rp = static_cast<HdAnariRenderParam *>(renderParam_);
+
     topology_ = HdMeshTopology(GetMeshTopology(sceneDelegate), 0);
     meshUtil_ = std::make_unique<HdAnariMeshUtil>(&topology_, GetId());
     adjacency_.reset();
 
-    VtVec3iArray triangulatedIndices;
-    VtIntArray trianglePrimitiveParams;
     meshUtil_->ComputeTriangleIndices(
-        &triangulatedIndices, &trianglePrimitiveParams_);
+        &triangulatedIndices_, &trianglePrimitiveParams_);
 
-    if (!triangulatedIndices.empty()) {
-      _SetGeometryAttributeArray(HdAnariTokens->index,
-          HdAnariTokens->primitiveIndex,
-          VtValue(triangulatedIndices),
-          ANARI_UINT32_VEC3);
+    // Create transient mapping structure to be able to map a face to its
+    // subdivised triangles. To be used to build geomsubset topology.
+    VtIntArray trianglesCounts;
+
+    auto count = 1ull;
+    auto prev = HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(
+        trianglePrimitiveParams_.front());
+    for (auto i = 1ull; i < trianglePrimitiveParams_.size(); ++i) {
+      auto pp = trianglePrimitiveParams_[i];
+      int faceIndex = HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(pp);
+      if (faceIndex != prev) {
+        trianglesCounts.push_back(count);
+        prev = faceIndex;
+        count = 1;
+      } else {
+        ++count;
+      }
+    }
+    trianglesCounts.push_back(count);
+
+    VtIntArray trianglesStarts(1, 0);
+    for (auto i = 0; i < trianglesCounts.size(); ++i) {
+      trianglesStarts.push_back(trianglesStarts.back() + trianglesCounts[i]);
+    }
+
+    // Build topology/triangle sets for each subgeom.
+    // Release any previously owned anari array before assigning the new one.
+    geomsubsets_ = topology_.GetGeomSubsets();
+    if (geomsubsets_.empty()) {
+      if (auto trianglesIt = geomSubsetTriangles_.find(GetId());
+          trianglesIt != cend(geomSubsetTriangles_)) {
+        anari::release(device_, trianglesIt->second);
+        geomSubsetTriangles_.erase(trianglesIt);
+      }
+
+      if (!triangulatedIndices_.empty()) {
+        geomSubsetTriangles_[GetId()] = _GetAttributeArray(
+            VtValue(triangulatedIndices_), ANARI_UINT32_VEC3);
+      }
     } else {
-      _SetGeometryAttributeArray(
-          HdAnariTokens->index, HdAnariTokens->primitiveIndex, VtValue());
+      // We go a slightly different path here.
+      // In order to be able to share faceVarying and face primvars between
+      // subsets, we generate degenerate triangles for triangles not belonging
+      // to the subset, so all topology have the same size.
+      for (auto subset : geomsubsets_) {
+        auto id = subset.id;
+
+        // Fill with a degenerate triangle, that is using vertices from the
+        // actual geomsubset so its extent stays valid.
+        VtVec3iArray indices(triangulatedIndices_.size(),
+            GfVec3i(triangulatedIndices_[trianglesStarts[0]][0]));
+
+        for (auto i : subset.indices) {
+          auto trianglesStart = trianglesStarts[i];
+          auto trianglesCount = trianglesCounts[i];
+
+          for (auto i = 0; i < trianglesCount; ++i) {
+            indices[trianglesStart + i] =
+                triangulatedIndices_[trianglesStart + i];
+          }
+        }
+
+        auto subsetTriangles =
+            _GetAttributeArray(VtValue(indices), ANARI_UINT32_VEC3);
+        geomSubsetTriangles_[id] = subsetTriangles;
+      }
     }
   }
 
-  // Normals
+  // Call the main geometry sync.
+  HdAnariGeometry::Sync(sceneDelegate, renderParam_, dirtyBits, reprToken);
+}
+
+HdGeomSubsets HdAnariMesh::GetGeomSubsets(
+    HdSceneDelegate *sceneDelegate, HdDirtyBits *dirtyBits)
+{
+  return geomsubsets_;
+}
+
+HdAnariGeometry::GeomSpecificPrimvars HdAnariMesh::GetGeomSpecificPrimvars(
+    HdSceneDelegate *sceneDelegate,
+    HdDirtyBits *dirtyBits,
+    const TfToken::Set &allPrimvars,
+    const VtVec3fArray &points,
+    const SdfPath &geomsetId)
+{
+  GeomSpecificPrimvars primvars;
+
+  // Topology
+  if (geomsubsets_.empty()) {
+    // Main topology only if no geomsubset is present
+    primvars.push_back(
+        {HdAnariTokens->primitiveIndex, geomSubsetTriangles_[GetId()]});
+  } else {
+    primvars.push_back(
+        {HdAnariTokens->primitiveIndex, geomSubsetTriangles_[geomsetId]});
+  }
+
+  // Normals smoothing if needed.
   const auto &normals = sceneDelegate->Get(GetId(), HdTokens->normals);
   bool normalIsAuthored =
       allPrimvars.find(HdTokens->normals) != std::cend(allPrimvars);
   bool doSmoothNormals = (topology_.GetScheme() != PxOsdOpenSubdivTokens->none)
       && (topology_.GetScheme() != PxOsdOpenSubdivTokens->bilinear);
 
-  if (normalIsAuthored) {
-    // Just return the binding information so that it is part of the overall
-    // primvar binding process.
-    return {{HdTokens->normals, HdAnariTokens->normal}};
-  } else if (doSmoothNormals) {
+  if (!normalIsAuthored && doSmoothNormals) {
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())
         || HdChangeTracker::IsPrimvarDirty(
             *dirtyBits, GetId(), HdTokens->points)) {
@@ -98,62 +193,59 @@ HdAnariMaterial::PrimvarBinding HdAnariMesh::UpdateGeometry(
         adjacency_->BuildAdjacencyTable(&topology_);
       }
 
-      if (TF_VERIFY(
-              points.IsHolding<VtVec3fArray>() && points.GetArraySize() > 0)) {
-        const auto &pointsArray = points.Get<VtVec3fArray>();
-        const VtVec3fArray &normals = Hd_SmoothNormals::ComputeSmoothNormals(
-            &*adjacency_, std::size(pointsArray), std::cbegin(pointsArray));
+      anari::release(device_, normals_);
 
-        _SetGeometryAttributeArray(HdAnariTokens->normal,
-            HdAnariTokens->vertexNormal,
-            VtValue(normals));
+      if (TF_VERIFY(std::size(points) > 0)) {
+        const VtVec3fArray &normals = Hd_SmoothNormals::ComputeSmoothNormals(
+            &*adjacency_, std::size(points), std::cbegin(points));
+        normals_ = _GetAttributeArray(VtValue(normals));
+        primvars.push_back({HdAnariTokens->vertexNormal, normals_});
       } else {
-        TF_RUNTIME_ERROR(
-            "Cannot find a valid points source to compute normal for %s\n",
-            GetId().GetText());
-        _SetGeometryAttributeArray(
-            HdAnariTokens->normal, HdAnariTokens->vertexNormal, VtValue());
+        normals_ = {};
       }
     }
   } else {
-    _SetGeometryAttributeArray(
-        HdAnariTokens->normal, HdAnariTokens->vertexNormal, VtValue());
+    anari::release(device_, normals_);
+    normals_ = {};
   }
 
-  return {};
+  return primvars;
 }
 
-void HdAnariMesh::UpdatePrimvarSource(HdSceneDelegate *sceneDelegate,
+HdAnariGeometry::PrimvarSource HdAnariMesh::UpdatePrimvarSource(
+    HdSceneDelegate *sceneDelegate,
     HdInterpolation interpolation,
     const TfToken &attributeName,
     const VtValue &value)
 {
   switch (interpolation) {
   case HdInterpolationConstant: {
-    _SetGeometryAttributeConstant(attributeName, value);
+    if (value.IsArrayValued()) {
+      if (value.GetArraySize() == 0) {
+        TF_RUNTIME_ERROR("Constant interpolation with no value.");
+        return {};
+      }
+      if (value.GetArraySize() > 1) {
+        TF_RUNTIME_ERROR("Constant interpolation with more than one value.");
+      }
+    }
+
+    GfVec4f v;
+    if (_GetVtValueAsAttribute(value, v)) {
+      return v;
+    } else {
+      TF_RUNTIME_ERROR(
+          "Error extracting value from primvar %s", attributeName.GetText());
+    }
     break;
   }
   case HdInterpolationUniform: {
     VtValue perFace;
     meshUtil_->GatherPerFacePrimvar(
         GetId(), attributeName, value, trianglePrimitiveParams_, &perFace);
-    auto bindingPoint = _GetPrimitiveBindingPoint(attributeName);
-    if (bindingPoint.IsEmpty()) {
-      TF_CODING_ERROR("%s is not a valid per primitive geometry attribute\n",
-          attributeName.GetText());
-      break;
-    }
-    _SetGeometryAttributeArray(attributeName, bindingPoint, perFace);
-    break;
+    return _GetAttributeArray(perFace);
   }
   case HdInterpolationFaceVarying: {
-    auto bindingPoint = _GetFaceVaryingBindingPoint(attributeName);
-    if (bindingPoint.IsEmpty()) {
-      TF_CODING_ERROR("%s is not a valid faceVarying geometry attribute\n",
-          attributeName.GetText());
-      break;
-    }
-
     HdVtBufferSource buffer(attributeName, value);
     VtValue triangulatedPrimvar;
     auto success =
@@ -163,28 +255,34 @@ void HdAnariMesh::UpdatePrimvarSource(HdSceneDelegate *sceneDelegate,
             &triangulatedPrimvar);
 
     if (success) {
-      _SetGeometryAttributeArray(
-          attributeName, bindingPoint, triangulatedPrimvar);
+      return _GetAttributeArray(triangulatedPrimvar);
     } else {
       TF_CODING_ERROR("     ERROR: could not triangulate face-varying data\n");
-      _SetGeometryAttributeArray(attributeName, bindingPoint, VtValue());
+      return {};
     }
     break;
   }
   case HdInterpolationVarying:
   case HdInterpolationVertex: {
-    auto bindingPoint = _GetVertexBindingPoint(attributeName);
-    if (bindingPoint.IsEmpty()) {
-      TF_CODING_ERROR("%s is not a valid vertex geometry attribute\n",
-          attributeName.GetText());
-      break;
-    }
-    _SetGeometryAttributeArray(attributeName, bindingPoint, value);
+    return _GetAttributeArray(value);
+  }
+  case HdInterpolationInstance:
+  case HdInterpolationCount:
+    assert(false);
     break;
   }
-  default:
-    break;
+
+  return {};
+}
+
+void HdAnariMesh::Finalize(HdRenderParam *renderParam_)
+{
+  anari::release(device_, normals_);
+  for (auto &pair : geomSubsetTriangles_) {
+    anari::release(device_, pair.second);
   }
+
+  HdAnariGeometry::Finalize(renderParam_);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/mesh.h
+++ b/src/hdanari/mesh.h
@@ -3,21 +3,31 @@
 
 #pragma once
 
-#include <anari/anari_cpp.hpp>
+#include "geometry.h"
+#include "meshUtil.h"
 
+// anari
+#include <anari/anari_cpp.hpp>
 // pxr
+#include <pxr/base/gf/vec3i.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/types.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/enums.h>
+#include <pxr/imaging/hd/geomSubset.h>
+#include <pxr/imaging/hd/meshTopology.h>
+#include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/types.h>
 #include <pxr/imaging/hd/vertexAdjacency.h>
+#include <pxr/imaging/hf/perfLog.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
-
-#include "geometry.h"
-#include "material.h"
-#include "meshUtil.h"
+// std
+#include <memory>
+#include <optional>
+#include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -31,12 +41,24 @@ class HdAnariMesh final : public HdAnariGeometry
 
   HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+  void Sync(HdSceneDelegate *sceneDelegate,
+      HdRenderParam *renderParam_,
+      HdDirtyBits *dirtyBits,
+      const TfToken &reprToken) override;
+
+  void Finalize(HdRenderParam *renderParam_) override;
+
  protected:
-  HdAnariMaterial::PrimvarBinding UpdateGeometry(HdSceneDelegate *sceneDelegate,
+  HdGeomSubsets GetGeomSubsets(
+      HdSceneDelegate *sceneDelegate, HdDirtyBits *dirtyBits) override;
+  HdAnariGeometry::GeomSpecificPrimvars GetGeomSpecificPrimvars(
+      HdSceneDelegate *sceneDelegate,
       HdDirtyBits *dirtyBits,
       const TfToken::Set &allPrimvars,
-      const VtValue &points) override;
-  void UpdatePrimvarSource(HdSceneDelegate *sceneDelegate,
+      const VtVec3fArray &points,
+      const SdfPath &geomsetId = {}) override;
+  HdAnariGeometry::PrimvarSource UpdatePrimvarSource(
+      HdSceneDelegate *sceneDelegate,
       HdInterpolation interpolation,
       const TfToken &attributeName,
       const VtValue &value) override;
@@ -49,7 +71,14 @@ class HdAnariMesh final : public HdAnariGeometry
   std::unique_ptr<HdAnariMeshUtil> meshUtil_;
   std::optional<Hd_VertexAdjacency> adjacency_;
 
+  HdGeomSubsets geomsubsets_;
+
+  VtVec3iArray triangulatedIndices_;
   VtIntArray trianglePrimitiveParams_;
+  anari::Array1D normals_{};
+
+  std::unordered_map<SdfPath, anari::Array1D, SdfPath::Hash>
+      geomSubsetTriangles_;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/meshUtil.cpp
+++ b/src/hdanari/meshUtil.cpp
@@ -3,19 +3,25 @@
 
 #include "meshUtil.h"
 
-#include <pxr/imaging/hd/perfLog.h>
-#include <pxr/imaging/hd/vtBufferSource.h>
-#include <pxr/pxr.h>
-
+// pxr
 #include <pxr/base/gf/vec2d.h>
 #include <pxr/base/gf/vec2f.h>
-#include <pxr/base/gf/vec2i.h>
 #include <pxr/base/gf/vec3d.h>
 #include <pxr/base/gf/vec3f.h>
-#include <pxr/base/gf/vec3i.h>
 #include <pxr/base/gf/vec4d.h>
 #include <pxr/base/gf/vec4f.h>
-#include <pxr/base/gf/vec4i.h>
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/trace/staticKeyData.h>
+#include <pxr/base/trace/trace.h>
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/types.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/imaging/hd/perfLog.h>
+#include <pxr/imaging/hd/types.h>
+#include <pxr/imaging/hd/vtBufferSource.h>
+#include <pxr/pxr.h>
+#include <pxr/usd/sdf/path.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -36,11 +42,32 @@ void HdAnariMeshUtil::GatherPerFacePrimVar(VtIntArray const &primitiveParams,
   *mappedPrimvar = results;
 }
 
+bool GatherGeomSubsetTopology(VtIntArray geomSubsetIndices,
+    VtIntArray primitiveParameters,
+    VtVec3iArray *triangleIndices)
+{
+  if (triangleIndices == nullptr) {
+    TF_CODING_ERROR(
+        "No output buffer provided for trianglulated geomsubset topology generation");
+    return false;
+  }
+
+  VtVec3iArray result;
+  // At least as many triangles as requested indices. It will be more in case
+  // of a non triangle mesh.
+  result.reserve(geomSubsetIndices.size());
+
+  for (auto index : geomSubsetIndices) {
+  }
+
+  return true;
+}
+
 bool HdAnariMeshUtil::GatherPerFacePrimvar(const SdfPath &id,
     const TfToken &pvname,
     VtValue value,
     VtIntArray primitiveParameters,
-    VtValue *mappedPrimvar) const
+    VtValue *mappedPrimvar)
 {
   HD_TRACE_FUNCTION();
 

--- a/src/hdanari/meshUtil.h
+++ b/src/hdanari/meshUtil.h
@@ -3,14 +3,12 @@
 
 #pragma once
 
-#include <pxr/imaging/hd/meshUtil.h>
-#include <pxr/pxr.h>
-
+#include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
 #include <pxr/base/vt/types.h>
 #include <pxr/base/vt/value.h>
-
-#include <pxr/base/tf/token.h>
+#include <pxr/imaging/hd/meshUtil.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -21,11 +19,15 @@ class HdAnariMeshUtil : public HdMeshUtil
   using HdMeshUtil::HdMeshUtil;
 
   // Gather per face primvar after a triangulation or quadrangulation
-  bool GatherPerFacePrimvar(const SdfPath &id,
+  static bool GatherPerFacePrimvar(const SdfPath &id,
       const TfToken &pvname,
       VtValue value,
       VtIntArray primitiveParameters,
-      VtValue *mappedPrimvar) const;
+      VtValue *mappedPrimvar);
+
+  static bool GatherGeomSubsetTopology(VtIntArray geomSubsetIndices,
+      VtIntArray primitiveParameters,
+      VtVec3iArray *triangleIndices);
 
  private:
   // Gather per face primvar after a triangulation or quadrangulation

--- a/src/hdanari/points.h
+++ b/src/hdanari/points.h
@@ -3,18 +3,20 @@
 
 #pragma once
 
+#include "geometry.h"
+// anari
+#include <anari/anari_cpp.hpp>
+// pxr
 #include <pxr/base/tf/token.h>
+#include <pxr/base/vt/types.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/enums.h>
-#include <anari/anari_cpp.hpp>
-
-// pxr
+#include <pxr/imaging/hd/geomSubset.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/types.h>
+#include <pxr/imaging/hf/perfLog.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
-
-#include "geometry.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -29,18 +31,31 @@ class HdAnariPoints final : public HdAnariGeometry
   HdDirtyBits GetInitialDirtyBitsMask() const override;
 
  protected:
-  HdAnariMaterial::PrimvarBinding UpdateGeometry(HdSceneDelegate *sceneDelegate,
+  HdGeomSubsets GetGeomSubsets(
+      HdSceneDelegate *sceneDelegate, HdDirtyBits *dirtyBits) override
+  {
+    return {};
+  }
+
+  HdAnariGeometry::GeomSpecificPrimvars GetGeomSpecificPrimvars(
+      HdSceneDelegate *sceneDelegate,
       HdDirtyBits *dirtyBits,
       const TfToken::Set &allPrimvars,
-      const VtValue &points) override;
-  void UpdatePrimvarSource(HdSceneDelegate *sceneDelegate,
+      const VtVec3fArray &points,
+      const SdfPath &geomsetId) override;
+  HdAnariGeometry::PrimvarSource UpdatePrimvarSource(
+      HdSceneDelegate *sceneDelegate,
       HdInterpolation interpolation,
       const TfToken &attributeName,
       const VtValue &value) override;
 
+  void Finalize(HdRenderParam *renderParam) override;
+
  private:
   HdAnariPoints(const HdAnariPoints &) = delete;
   HdAnariPoints &operator=(const HdAnariPoints &) = delete;
+
+  anari::Array1D m_radiiArray{};
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
This update bring two changes:
- Drop support for non array based instancing.  KHR_INSTANCE_TRANSFORM_ARRAY extension is now expected on the device.
- Add UsdGeomSubset support for meshes. UsdGeomSubset gives the ability to share geometrical support and primvars while using different materials for different subparts of a mesh. This requires a caching strategy update, as for now, the code relies on anari::Geometry and anari:: Instance retaining their assigned buffers and does not do any further tracking.

This PR updates the caching strategy so that:
- the HdAnariGeometry class and related handle the lifetime of the anari data instead of relying on the anari::Geometry retaining its inputs as done before. This enables sharing the content between geomsubsets.
- geometric specific primvars (such as topology for meshes and radii for points) are handled by the HdAnariGeometry subclasses themselves and share this content with the main HdAnariGeometry class for exposure to anari objects.
