### PR TITLE
avoid calling GetCurrentDirectory() with un-initialized memory location

### DIFF
--- a/src/anari/LibraryImpl.cpp
+++ b/src/anari/LibraryImpl.cpp
@@ -101,7 +101,8 @@ static void *loadLibrary(
   else if (withAnchor && dwRet == 0)
     errorMsg = "GetCurrentDirectory() failed for unknown reason";
   else {
-    SetCurrentDirectory(libLocation.c_str());
+    if (/* this check only avoids a 'SetCurrentDir("")' */ withAnchor)
+      SetCurrentDirectory(libLocation.c_str());
 
     // Load the library
     std::string fullName = libLocation + file + ".dll";
@@ -123,8 +124,12 @@ static void *loadLibrary(
       LocalFree(lpMsgBuf);
     }
 
-    // Change cwd back to its original value
-    SetCurrentDirectory(currentWd);
+    // iw: check if 'withAnchor' is on - if now, currentWd has never been queried
+    // and points to an un-initialized memory location
+    if (withAnchor) {
+      // Change cwd back to its original value
+      SetCurrentDirectory(currentWd);
+    }
   }
 
 #else


### PR DESCRIPTION
The way I read the current code (and what my debug printouts bear out) in the existing code the first call to loadLibrary has 'withAnchor' set to false, and the code then does _not_ query the current work directory (ie `currentWD` remains an uninitialized stack array), then the code goes into the else() branch where it will then - at the end of that code block - call SetCurrentDir() with that un-initialized memory region.

This fix avoids that, and does SetCurrentDir only if setanchor is true.