### PR TITLE
allow specifying -DANARI_LIBRARY_ONLY=ON on build time

### DIFF
--- a/cts/CMakeLists.txt
+++ b/cts/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 cmake_minimum_required(VERSION 3.1)
 
+if (ANARI_LIBRARY_ONLY)
+  return()
+endif()
+
 # Fix "DOWNLOAD_EXTRACT_TIMESTAMP" warning
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,12 @@
 ## SPDX-License-Identifier: Apache-2.0
 
 # Example applications which use the ANARI API
+
+if (ANARI_LIBRARY_ONLY)
+  return()
+endif()
+   
+
 add_subdirectory(simple)
 
 option(BUILD_VIEWER "Build interactive viewer app (requires GLFW)" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 ## Copyright 2021-2024 The Khronos Group
 ## SPDX-License-Identifier: Apache-2.0
 
+if (ANARI_LIBRARY_ONLY)
+  add_subdirectory(anari)
+  add_subdirectory(helium)
+  return()
+endif()
+
 add_subdirectory(anari)
 add_subdirectory(anari_test_scenes)
 add_subdirectory(anari_viewer)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 ## Copyright 2021-2024 The Khronos Group
 ## SPDX-License-Identifier: Apache-2.0
 
+if (ANARI_LIBRARY_ONLY)
+  return()
+endif()
+   
 add_subdirectory(unit)
 add_subdirectory(render)


### PR DESCRIPTION
By default anari sdk builds multiple components that are not actually required to build an anari device; soem of those (like helide) can be turned off individually, others (anari test scenes and samples) cannot. 
This PR adds a feature that, if ANARI_LIBRARY_ONLY is set at configure time, will only build and install libanai, helium, and header files as required to build a device.