### PR TITLE
hdanari: Expose pixelSamples renderer parameter

### DIFF
--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -136,6 +136,9 @@ void HdAnariRenderDelegate::Initialize()
       {"Max Ray Depth", HdAnariRenderSettingsTokens->maxRayDepth, VtValue(0)});
 
   _settingDescriptors.push_back(
+      { "Pixel Samples",HdAnariRenderSettingsTokens->pixelSamples, VtValue(1) });
+
+  _settingDescriptors.push_back(
       {"Denoise", HdAnariRenderSettingsTokens->denoise, VtValue(false)});
 
   _settingDescriptors.push_back({"subtype",

--- a/src/hdanari/rd/renderDelegate.h
+++ b/src/hdanari/rd/renderDelegate.h
@@ -18,9 +18,18 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdAnariRenderParam;
 
+// clang-format off
 #define HDANARI_RENDER_SETTINGS_TOKENS                                         \
-  (ambientRadiance)(ambientColor)(                                             \
-      ambientSamples)(sampleLimit)(maxRayDepth)(denoise)(renderSubtype)(debugMethod)
+  (ambientColor) \
+  (ambientRadiance) \
+  (ambientSamples) \
+  (debugMethod) \
+  (denoise) \
+  (maxRayDepth) \
+  (pixelSamples) \
+  (renderSubtype) \
+  (sampleLimit)
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     HdAnariRenderSettingsTokens, HDANARI_RENDER_SETTINGS_TOKENS);

--- a/src/hdanari/rd/renderPass.cpp
+++ b/src/hdanari/rd/renderPass.cpp
@@ -194,6 +194,13 @@ void HdAnariRenderPass::_UpdateRenderer()
           d, _anari.renderer, "maxRayDepth", rb.UncheckedGet<int>());
     }
 
+    if (const auto ps = renderDelegate->GetRenderSetting(
+        HdAnariRenderSettingsTokens->pixelSamples);
+        TF_VERIFY(ps.IsHolding<int>())) {
+      anari::setParameter(
+          d, _anari.renderer, "pixelSamples", ps.UncheckedGet<int>());
+    }
+
     if (const auto denoise =
         renderDelegate->GetRenderSetting(HdAnariRenderSettingsTokens->denoise);
         TF_VERIFY(denoise.IsHolding<bool>())) {


### PR DESCRIPTION
Expose an new pixelSamples parameter that maps to renderer's pixelSamples. Defaults to one.

<img width="403" height="355" alt="image" src="https://github.com/user-attachments/assets/46281165-744a-492e-a059-d4a1b0fc64d1" />
