### PR TITLE
Add clamp to border extension

### DIFF
--- a/code_gen/api/khr_sampler_image1d.json
+++ b/code_gen/api/khr_sampler_image1d.json
@@ -41,7 +41,7 @@
                     "values" : ["nearest", "linear"],
                     "description" : "filter mode"
                 }, {
-                    "name" : "wrapMode1",
+                    "name" : "wrapMode",
                     "types" : ["ANARI_STRING"],
                     "tags" : [],
                     "default" : "clampToEdge",

--- a/code_gen/api/khr_sampler_imagexd_clamp_to_border.json
+++ b/code_gen/api/khr_sampler_imagexd_clamp_to_border.json
@@ -1,0 +1,73 @@
+{
+    "info" : {
+        "name" : "KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER",
+        "type" : "extension",
+        "dependencies" : ["khr_sampler_image1d", "khr_sampler_image2d", "khr_sampler_image3d"]
+    },
+
+    "objects" : [
+        {
+            "type" : "ANARI_SAMPLER",
+            "name" : "image1D",
+            "parameters" : [
+                {
+                    "name" : "wrapMode",
+                    "values" : ["clampToBorder"]
+                },
+                {
+                    "name" : "borderColor",
+                    "types" : ["ANARI_FLOAT32_VEC4"],
+                    "tags" : ["color"],
+                    "default" : [0.0, 0.0, 0.0, 0.0],
+                    "description" : "color of the border when clampToBorder wrap mode is used"
+                }
+            ]
+        },
+        {
+            "type" : "ANARI_SAMPLER",
+            "name" : "image2D",
+            "parameters" : [
+                {
+                    "name" : "wrapMode1",
+                    "values" : ["clampToBorder"]
+                },
+                {
+                    "name" : "wrapMode2",
+                    "values" : ["clampToBorder"]
+                },
+                {
+                    "name" : "borderColor",
+                    "types" : ["ANARI_FLOAT32_VEC4"],
+                    "tags" : ["color"],
+                    "default" : [0.0, 0.0, 0.0, 0.0],
+                    "description" : "color of the border when clampToBorder wrap mode is used"
+                }
+            ]
+        },
+        {
+            "type" : "ANARI_SAMPLER",
+            "name" : "image3D",
+            "parameters" : [
+                {
+                    "name" : "wrapMode1",
+                    "values" : ["clampToBorder"]
+                },
+                {
+                    "name" : "wrapMode2",
+                    "values" : ["clampToBorder"]
+                },
+                {
+                    "name" : "wrapMode3",
+                    "values" : ["clampToBorder"]
+                },
+                {
+                    "name" : "borderColor",
+                    "types" : ["ANARI_FLOAT32_VEC4"],
+                    "tags" : ["color"],
+                    "default" : [0.0, 0.0, 0.0, 0.0],
+                    "description" : "color of the border when clampToBorder wrap mode is used"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Matching specification update: https://github.com/KhronosGroup/ANARI-Docs/pull/169

Also fixed an inconsistency between the specs and matching json for image1D.wrapMode.