### PR TITLE
Apply correct coordinate wrapping for REPEAT mode in Image1D/2D/3D

### DIFF
--- a/src/devices/helide/sampler/Image1D.cpp
+++ b/src/devices/helide/sampler/Image1D.cpp
@@ -38,7 +38,11 @@ float4 Image1D::getSample(
                 m_inTransform, ia ? *ia : g.getAttributeValue(m_inAttribute, r))
       + m_inOffset;
 
-  const auto interp = getInterpolant(av.x, m_image->size(), true);
+  // Select the appropriate coordinate wrapping mode for x.
+  // If the wrap mode is REPEAT, the coordinate is wrapped using fract();
+  // otherwise, it is left unchanged.
+  float x = m_wrapMode == WrapMode::REPEAT ? fract(av.x) : av.x;
+  const auto interp = getInterpolant(x, m_image->size(), true);
   const auto v0 = m_image->readAsAttributeValue(interp.lower, m_wrapMode);
   const auto v1 = m_image->readAsAttributeValue(interp.upper, m_wrapMode);
   const auto retval = m_linearFilter ? linalg::lerp(v0, v1, interp.frac)

--- a/src/devices/helide/sampler/Image2D.cpp
+++ b/src/devices/helide/sampler/Image2D.cpp
@@ -39,8 +39,14 @@ float4 Image2D::getSample(
                 m_inTransform, ia ? *ia : g.getAttributeValue(m_inAttribute, r))
       + m_inOffset;
 
-  const auto interp_x = getInterpolant(av.x, m_image->size().x, true);
-  const auto interp_y = getInterpolant(av.y, m_image->size().y, true);
+  // Select the appropriate coordinate wrapping mode for x and y.
+  // If the wrap mode is REPEAT, the coordinate is wrapped using fract();
+  // otherwise, it is left unchanged.
+  float x = m_wrapMode1 == WrapMode::REPEAT ? fract(av.x) : av.x;
+  float y = m_wrapMode2 == WrapMode::REPEAT ? fract(av.y) : av.y;
+
+  const auto interp_x = getInterpolant(x, m_image->size().x, true);
+  const auto interp_y = getInterpolant(y, m_image->size().y, true);
   const auto v00 = m_image->readAsAttributeValue(
       {interp_x.lower, interp_y.lower}, m_wrapMode1, m_wrapMode2);
   const auto v01 = m_image->readAsAttributeValue(

--- a/src/devices/helide/sampler/Image3D.cpp
+++ b/src/devices/helide/sampler/Image3D.cpp
@@ -38,9 +38,16 @@ float4 Image3D::getSample(
                 m_inTransform, ia ? *ia : g.getAttributeValue(m_inAttribute, r))
       + m_inOffset;
 
-  const auto interp_x = getInterpolant(av.x, m_image->size().x, true);
-  const auto interp_y = getInterpolant(av.y, m_image->size().y, true);
-  const auto interp_z = getInterpolant(av.z, m_image->size().z, true);
+  // Select the appropriate coordinate wrapping mode for x, y and z.
+  // If the wrap mode is REPEAT, the coordinate is wrapped using fract();
+  // otherwise, it is left unchanged.
+  float x = m_wrapMode1 == WrapMode::REPEAT ? fract(av.x) : av.x;
+  float y = m_wrapMode2 == WrapMode::REPEAT ? fract(av.y) : av.y;
+  float z = m_wrapMode3 == WrapMode::REPEAT ? fract(av.z) : av.z;
+
+  const auto interp_x = getInterpolant(x, m_image->size().x, true);
+  const auto interp_y = getInterpolant(y, m_image->size().y, true);
+  const auto interp_z = getInterpolant(z, m_image->size().z, true);
 
   const auto v000 = m_image->readAsAttributeValue(
       {interp_x.lower, interp_y.lower, interp_z.lower},

--- a/src/helium/helium_math.h
+++ b/src/helium/helium_math.h
@@ -185,6 +185,11 @@ inline int32_t calculateWrapIndex(int32_t i, size_t size, WrapMode wrap)
   }
 }
 
+inline float fract(float v)
+{
+  return v - std::floor(v);
+}
+
 inline Attribute attributeFromString(const std::string &str)
 {
   if (str == "color")


### PR DESCRIPTION
Ensure that texture coordinates are wrapped using fract() when the wrap mode is REPEAT in Image1D, Image2D, and Image3D samplers. This fixes incorrect sampling at texture boundaries for repeating textures. Adds a `fract()` helper to `helium_math.h` for this purpose.

The below images were created with VTK and `helide` with a texture coodinate range of [0,1] along the Y axis and a texture wrapping mode as `REPEAT`. 

| Texture Coordinate Range along X axis | Before this change | After this change |
|:---:|:---:|:---:|
| [0, 1] | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/fdb93bd5-2b89-4865-85e7-9a9d94a96a12" /> |  <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/94889226-eff8-406d-a9b4-30b05123b1c6" /> |
| [-1, 0] | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/95b6fa79-bc70-46bc-8b73-8e658bf38bb1" /> | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/03bc2eb8-6e93-4f97-8103-2b13cb6f2fe7" /> |
| [-0.5, 0.5] | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/f1a78957-f903-4ad9-bf77-61846f399428" /> | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/923c044d-4973-4540-b525-12555684a377" /> |
| [-1.3, 1.2] | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/a2930bd4-5a71-4f9c-afb1-8094f43230d9" /> | <img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/7d54aeba-74c8-4593-938c-dc0533a870df" /> |
