### PR TITLE
Fixed size and format crash when resized window maps old frame contents

### DIFF
--- a/src/anari_viewer/windows/Viewport.cpp
+++ b/src/anari_viewer/windows/Viewport.cpp
@@ -283,12 +283,13 @@ void Viewport::updateImage()
 
     auto fb = anari::map<void>(m_device, m_frame, "channel.color");
 
-    if (fb.data && fb.pixelType == m_format) {
+    if (fb.data && fb.pixelType == m_format
+        && fb.width == m_viewportSize.x && fb.height == m_viewportSize.y) {
       SDL_UpdateTexture(m_framebufferTexture,
           nullptr,
           fb.data,
           fb.width * anari::sizeOf(m_format));
-    } else {
+    } else if (!fb.data || fb.pixelType != m_format) {
       printf("mapped bad frame: %p | %i x %i\n", fb.data, fb.width, fb.height);
     }
 


### PR DESCRIPTION
DX11 textures updated with outdatted mapped frame data not corresponding to the new size/format will cause a crash.