### PR TITLE
fixed stb warnings

### DIFF
--- a/external/stb_image/stb_image.h
+++ b/external/stb_image/stb_image.h
@@ -4940,12 +4940,14 @@ static void stbi__de_iphone(stbi__png *z)
 static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
 {
    stbi_uc palette[1024], pal_img_n=0;
-   stbi_uc has_trans=0, tc[3]={0};
+   stbi_uc has_trans=0;
+   stbi_uc tc[3];
    stbi__uint16 tc16[3];
    stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
    int first=1,k,interlace=0, color=0, is_iphone=0;
    stbi__context *s = z->s;
-
+   tc[0] = tc[1] = tc[2] = 0;
+   
    z->expanded = NULL;
    z->idata = NULL;
    z->out = NULL;
@@ -5023,7 +5025,8 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                if (z->depth == 16) {
                   for (k = 0; k < s->img_n; ++k) tc16[k] = (stbi__uint16)stbi__get16be(s); // copy the values as-is
                } else {
-                  for (k = 0; k < s->img_n; ++k) tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
+                 for (k = 0; k < s->img_n && k < 3; ++k)
+                   tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
                }
             }
             break;


### PR DESCRIPTION
this fixes the STB related warnings when the compiler encounters the tc[3]={0} and related locations.
