### PR TITLE
Fix Embree alignment error by adding alignas to the Ray struct

### DIFF
--- a/src/devices/helide/HelideMath.h
+++ b/src/devices/helide/HelideMath.h
@@ -17,7 +17,7 @@ using namespace anari::math;
 using namespace helium::math;
 using namespace embree_for_helide;
 
-struct Ray
+struct alignas(16) Ray
 {
   // Ray //
 


### PR DESCRIPTION
The helide device's Ray struct was missing the 16-byte alignment that embree requires. This was causing "ray not aligned to 16 bytes" errors when using the helide device.