### PR TITLE
Fix ANARIlibrary release

### DIFF
--- a/src/anari/API.cpp
+++ b/src/anari/API.cpp
@@ -112,7 +112,6 @@ extern "C" ANARILibrary anariLoadLibrary(const char *libraryName,
     if (!lib)
       throw std::runtime_error("failed to load library " + libname);
 
-
     std::string prefix = "anari_library_" + libname;
     std::string newLibraryFcnName = prefix + "_new_library";
 
@@ -120,8 +119,8 @@ extern "C" ANARILibrary anariLoadLibrary(const char *libraryName,
         (NewLibraryFcn)anari::getSymbolAddress(lib, newLibraryFcnName);
 
     if (!newLibraryFcn) {
-      throw std::runtime_error("failed to find entrypoint function for "
-          + libname + " library");
+      throw std::runtime_error(
+          "failed to find entrypoint function for " + libname + " library");
     }
   } catch (const std::exception &e) {
     std::string msg = "failed to load ANARILibrary '";
@@ -145,7 +144,15 @@ ANARI_CATCH_END(nullptr)
 
 extern "C" void anariUnloadLibrary(ANARILibrary l) ANARI_CATCH_BEGIN
 {
-  delete (LibraryImpl *)l;
+  if (!l)
+    return;
+
+  auto *impl = (LibraryImpl *)l;
+  void *lib = impl->libraryHandle();
+  delete impl;
+  // Free the OS handle only after the object (which lives in that module) is
+  // gone, otherwise we unmap code mid-delete and crash. See LibraryImpl.cpp.
+  anari::freeLibrary(lib);
 }
 ANARI_CATCH_END_NORETURN()
 

--- a/src/anari/API.cpp
+++ b/src/anari/API.cpp
@@ -145,7 +145,7 @@ ANARI_CATCH_END(nullptr)
 
 extern "C" void anariUnloadLibrary(ANARILibrary l) ANARI_CATCH_BEGIN
 {
-  delete l;
+  delete (LibraryImpl *)l;
 }
 ANARI_CATCH_END_NORETURN()
 

--- a/src/anari/LibraryImpl.cpp
+++ b/src/anari/LibraryImpl.cpp
@@ -83,17 +83,15 @@ static std::vector<void *> g_loadedLibs;
 static void *loadLibrary(
     const std::string &libName, bool withAnchor, std::string &errorMessage)
 {
-
   auto n = libName.find(',');
   std::string name = libName.substr(0, n);
 
   std::string file = std::string("anari_library_") + name;
   std::string errorMsg;
   std::string libLocation = withAnchor ? library_location() : std::string();
-  if(n != libName.npos) {
-    libLocation = libName.substr(n+1);
+  if (n != libName.npos) {
+    libLocation = libName.substr(n + 1);
   }
-
 
   void *lib = nullptr;
 #ifdef _WIN32
@@ -195,10 +193,10 @@ LibraryImpl::LibraryImpl(
       m_defaultStatusCBUserPtr(statusCBPtr)
 {}
 
-LibraryImpl::~LibraryImpl()
-{
-  freeLibrary(m_lib);
-}
+// Do not freeLibrary(m_lib) here: this object lives in the module being
+// freed. Unloading it from the destructor unmaps the code that finishes the
+// delete. anariUnloadLibrary() frees the handle after the object is destroyed.
+LibraryImpl::~LibraryImpl() = default;
 
 ANARIDevice LibraryImpl::newInitializedDevice(
     const char *subtype, ANARIParameterValue *)
@@ -236,6 +234,11 @@ const void *LibraryImpl::defaultStatusCBUserPtr() const
 ANARILibrary LibraryImpl::this_library() const
 {
   return (ANARILibrary)this;
+}
+
+void *LibraryImpl::libraryHandle() const
+{
+  return m_lib;
 }
 
 ANARI_TYPEFOR_DEFINITION(LibraryImpl *);

--- a/src/anari/include/anari/backend/LibraryImpl.h
+++ b/src/anari/include/anari/backend/LibraryImpl.h
@@ -48,6 +48,12 @@ struct LibraryImpl
   // Utility to get 'this' pointer as an ANARILibrary handle
   ANARILibrary this_library() const;
 
+  // Get the loaded OS library handle. The handle must only be freed (via
+  // freeLibrary()) after this object is destroyed, never from within the
+  // destructor: the object lives in the module being freed, so unloading it
+  // mid-destruction unmaps the code that completes the delete.
+  void *libraryHandle() const;
+
  private:
   void *m_lib{nullptr};
 


### PR DESCRIPTION
Fix two issues that we preventing library release from operating correctly:
- the ANARIlibrary destructor was called on an opaque (`struct {}`) object instead of the actual polymorphic type
- the destructor call was unloading the library shared object while its code was in flight

Addresses the following valgrind error:
```
==79272== Mismatched new/delete size value: 1
==79272==    at 0x7E6DEB9: operator delete(void*, unsigned long) (in /nix/store/z3k1ih7g5njqnbhns0anx8mw6zqjs1z3-valgrind-3.26.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==79272==    by 0x40DA460: anari::unloadLibrary(anari::api::Library*) (anari_cpp_impl.hpp:41)
==79272==    by 0x4A5908E: tsd::app::ANARIDeviceManager::loadDevice(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, tsd::core::Any>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, tsd::core::Any> > > const&) (ANARIDeviceManager.cpp:123)
==79272==    by 0x4A62283: tsd::app::Context::setOfflineRenderingLibrary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (Context.cpp:211)
==79272==    by 0x406B45A: tsd::ui::imgui::AppSettingsDialog::AppSettingsDialog(tsd::ui::imgui::Application*) (AppSettingsDialog.cpp:17)
==79272==    by 0x4117417: std::__detail::_MakeUniq<tsd::ui::imgui::AppSettingsDialog>::__single_object std::make_unique<tsd::ui::imgui::AppSettingsDialog, tsd::ui::imgui::Application*>(tsd::ui::imgui::Application*&&) (unique_ptr.h:1085)
==79272==    by 0x41096E3: tsd::ui::imgui::Application::setupWindows() (Application.cpp:382)
==79272==    by 0x414656E: tsd_viewer::Application::setupWindows() (tsdViewer.cpp:90)
==79272==    by 0x4107AFB: tsd::ui::imgui::Application::run(int, int, char const*) (Application.cpp:81)
==79272==    by 0x4144A78: main (tsdViewer.cpp:361)
==79272==  Address 0x192feb290 is 0 bytes inside a block of size 32 alloc'd
==79272==    at 0x7E69FBB: operator new(unsigned long) (in /nix/store/z3k1ih7g5njqnbhns0anx8mw6zqjs1z3-valgrind-3.26.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==79272==    by 0x1C63BC71D: anari_library_sink_new_library (in /nix/store/gi5cwvpb1hzzxiv5h2f7jd3icq92a6id-anari-sdk-0.15.0-unstable-2026-06-02/lib/libanari_library_sink.so)
==79272==    by 0x292BE5A7: anariLoadLibrary (in /nix/store/gi5cwvpb1hzzxiv5h2f7jd3icq92a6id-anari-sdk-0.15.0-unstable-2026-06-02/lib/libanari.so.0.16.0)
==79272==    by 0x40DA446: anari::loadLibrary(char const*, void (*)(void const*, anari::api::Device*, anari::api::Object*, ANARIDataType, int, int, char const*), void const*) (anari_cpp_impl.hpp:36)
==79272==    by 0x4A58EF6: tsd::app::ANARIDeviceManager::loadDevice(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, tsd::core::Any>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, tsd::core::Any> > > const&) (ANARIDeviceManager.cpp:114)
==79272==    by 0x4A62283: tsd::app::Context::setOfflineRenderingLibrary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (Context.cpp:211)
==79272==    by 0x406B45A: tsd::ui::imgui::AppSettingsDialog::AppSettingsDialog(tsd::ui::imgui::Application*) (AppSettingsDialog.cpp:17)
==79272==    by 0x4117417: std::__detail::_MakeUniq<tsd::ui::imgui::AppSettingsDialog>::__single_object std::make_unique<tsd::ui::imgui::AppSettingsDialog, tsd::ui::imgui::Application*>(tsd::ui::imgui::Application*&&) (unique_ptr.h:1085)
==79272==    by 0x41096E3: tsd::ui::imgui::Application::setupWindows() (Application.cpp:382)
==79272==    by 0x414656E: tsd_viewer::Application::setupWindows() (tsdViewer.cpp:90)
==79272==    by 0x4107AFB: tsd::ui::imgui::Application::run(int, int, char const*) (Application.cpp:81)
==79272==    by 0x4144A78: main (tsdViewer.cpp:361)
```