### PR TITLE
Fix curve with implicit index

### DIFF
--- a/src/devices/helide/geometry/Curve.cpp
+++ b/src/devices/helide/geometry/Curve.cpp
@@ -40,7 +40,7 @@ void Curve::finalize()
   m_globalRadius = getParam<float>("radius", 1.f);
 
   const auto numSegments =
-      m_index ? m_index->size() : m_vertexPosition->size() / 2;
+      m_index ? m_index->size() : m_vertexPosition->size() - 1;
 
   {
     auto *vr = (float4 *)rtcSetNewGeometryBuffer(embreeGeometry(),


### PR DESCRIPTION
Spec:
>  If no `primitive.index` is given, then a single curve is assumed, connecting all vertices.