### PR TITLE
cts: Add ray/primitive intersection edge-case tests

### DIFF
--- a/src/anari_test_scenes/cts/tests/geometry.cpp
+++ b/src/anari_test_scenes/cts/tests/geometry.cpp
@@ -248,8 +248,109 @@ anari::World isosurfaceWorld(BuildContext &ctx)
   return world;
 }
 
+// ---- intersection edge cases ----------------------------------------------
+// Single-primitive worlds paired with a bespoke camera, built to stress a
+// device's ray/primitive intersector rather than its attribute plumbing:
+// origin-inside hits (the far root), near-axis-parallel and grazing rays
+// (the degenerate a~=0 / discriminant~=0 lateral-surface roots), the cone
+// apex singularity, and every spec value of the tube-family `caps`
+// parameter viewed where caps actually resolve differently. The tests
+// encode the behavior the spec describes, independent of what any current
+// device renders.
+//
+// Exterior views score color + depth: a wrong root can shade plausibly but
+// lands at a very different depth. The origin-inside tests score depth only —
+// it is the device-independent intersection oracle. Their interior (back-
+// facing) hit is deliberately not lit: an interior point light does not
+// reliably illuminate a back face (whether the shading normal flips there is
+// device-dependent, and ambient/AO is legitimately black inside a closed
+// object), so a color image would be near-black on some devices and mislead a
+// color comparison. Depth is populated regardless of shading.
+
+anari::World litSurfaceWorld(
+    BuildContext &ctx, anari::Geometry geom, float3 lightDir)
+{
+  auto d = ctx.device();
+  auto mat = makeMatteMaterial(d, float3(0.7f, 0.5f, 0.3f));
+  auto surface = makeSurface(d, geom, mat);
+  auto light = makeDirectionalLight(d, lightDir);
+  WorldContents contents;
+  contents.surfaces = {surface};
+  contents.lights = {light};
+  auto world = assembleWorld(d, contents);
+  anari::release(d, geom);
+  anari::release(d, mat);
+  anari::release(d, surface);
+  anari::release(d, light);
+  return world;
+}
+
+anari::Geometry spheres(anari::Device d,
+    const std::vector<float3> &centers,
+    const std::vector<float> &radii)
+{
+  auto g = anari::newObject<anari::Geometry>(d, "sphere");
+  anari::setAndReleaseParameter(d,
+      g,
+      "vertex.position",
+      anari::newArray1D(d, centers.data(), centers.size()));
+  anari::setAndReleaseParameter(
+      d, g, "vertex.radius", anari::newArray1D(d, radii.data(), radii.size()));
+  anari::commitParameters(d, g);
+  return g;
+}
+
+anari::Geometry axisCylinder(
+    anari::Device d, float3 p0, float3 p1, float radius, const char *caps)
+{
+  auto g = anari::newObject<anari::Geometry>(d, "cylinder");
+  const float3 positions[2] = {p0, p1};
+  anari::setAndReleaseParameter(
+      d, g, "vertex.position", anari::newArray1D(d, positions, 2));
+  anari::setParameter(d, g, "radius", radius);
+  anari::setParameter(d, g, "caps", caps);
+  anari::commitParameters(d, g);
+  return g;
+}
+
+anari::Geometry axisCone(anari::Device d,
+    float3 base,
+    float3 apex,
+    float baseRadius,
+    const char *caps)
+{
+  auto g = anari::newObject<anari::Geometry>(d, "cone");
+  const float3 positions[2] = {base, apex};
+  anari::setAndReleaseParameter(
+      d, g, "vertex.position", anari::newArray1D(d, positions, 2));
+  const float radii[2] = {baseRadius, 0.f};
+  anari::setAndReleaseParameter(
+      d, g, "vertex.radius", anari::newArray1D(d, radii, 2));
+  anari::setParameter(d, g, "caps", caps);
+  anari::commitParameters(d, g);
+  return g;
+}
+
+anari::Camera lookAtCamera(
+    anari::Device d, float3 eye, float3 direction, float fovy, float near)
+{
+  auto c = anari::newObject<anari::Camera>(d, "perspective");
+  anari::setParameter(d, c, "position", eye);
+  anari::setParameter(d, c, "direction", direction);
+  anari::setParameter(d, c, "up", float3(0.f, 1.f, 0.f));
+  anari::setParameter(d, c, "fovy", fovy);
+  anari::setParameter(d, c, "near", near);
+  anari::setParameter(d, c, "far", 100.f);
+  anari::commitParameters(d, c);
+  return c;
+}
+
+const char *kPerspective = "ANARI_KHR_CAMERA_PERSPECTIVE";
+const float3 kEdgeLight = float3(-1.f, -1.f, -1.f);
+
 const std::vector<Channel> kColorDepth = {Channel::Color, Channel::Depth};
 const std::vector<Channel> kColorOnly = {Channel::Color};
+const std::vector<Channel> kDepthOnly = {Channel::Depth};
 
 const std::vector<Any> kFrameColorTypes = {
     Any("UFIXED8_VEC4"), Any("UFIXED8_RGBA_SRGB"), Any("FLOAT32_VEC4")};
@@ -598,6 +699,180 @@ void registerGeometryTests(Catalog &catalog)
       })
       .channels(kColorDepth)
       .requireFeatures({"ANARI_KHR_GEOMETRY_CYLINDER", kMatte})
+      .registerInto(catalog);
+
+  // ---- intersection edge cases ----------------------------------------------
+  // Camera inside a large sphere, slightly off-center so the generic interior
+  // root (b != 0) is exercised and the frame is not rotationally symmetric:
+  // every primary ray must return the far (exit) hit against the interior
+  // wall. The small foreground sphere the camera sits outside of serves the
+  // depth oracle twice: central rays now carry two candidate hits — its near
+  // exterior root must win over the enclosing sphere's far interior root
+  // (nearest-hit ordering with an origin-inside primitive) — and its step
+  // discontinuity keeps the depth comparison sensitive where a lone interior
+  // wall would be a near-uniform gradient.
+  makeTest("geometry", "sphere_interior")
+      .description(
+          "Checks sphere intersection when the ray origin is inside the "
+          "sphere (far-root hit against the interior wall).")
+      .build([](BuildContext &ctx) {
+        return litSurfaceWorld(ctx,
+            spheres(ctx.device(),
+                {float3(0.f), float3(0.f, 0.f, -0.6f)},
+                {1.f, 0.3f}),
+            kEdgeLight);
+      })
+      .camera([](BuildContext &ctx, const scenes::Bounds &) {
+        return lookAtCamera(ctx.device(),
+            float3(0.15f, 0.1f, 0.1f),
+            float3(0.f, 0.f, -1.f),
+            1.2f,
+            0.001f);
+      })
+      .channels(kDepthOnly)
+      .requireFeatures({"ANARI_KHR_GEOMETRY_SPHERE", kMatte, kPerspective})
+      .registerInto(catalog);
+
+  // Eye offset just outside the cylinder radius, view direction parallel to
+  // the axis: the frame contains exactly-parallel misses, a band of
+  // near-parallel rays grazing the outer wall (the a ~= 0 lateral-surface
+  // root), and the near end face-on. Every spec caps value resolves
+  // differently down the bore: "second"/"both" close the near end (p1, the
+  // end facing the eye), "first" leaves it open onto the far cap (p0) seen
+  // down the bore past the interior wall, and "none" leaves the bore open to
+  // the background.
+  makeTest("geometry", "cylinder_axis_view")
+      .description(
+          "Checks cylinder intersection for rays nearly parallel to the "
+          "cylinder axis (degenerate lateral-surface root) across all spec "
+          "cap modes, viewed down the bore.")
+      .build([](BuildContext &ctx) {
+        return litSurfaceWorld(ctx,
+            axisCylinder(ctx.device(),
+                float3(0.f, 0.f, -0.5f),
+                float3(0.f, 0.f, 0.5f),
+                0.3f,
+                ctx.getString("caps", "none").c_str()),
+            kEdgeLight);
+      })
+      .camera([](BuildContext &ctx, const scenes::Bounds &) {
+        return lookAtCamera(ctx.device(),
+            float3(0.45f, 0.1f, 2.f),
+            float3(0.f, 0.f, -1.f),
+            0.6f,
+            0.01f);
+      })
+      .permute("caps", {"none", "first", "second", "both"})
+      .channels(kColorDepth)
+      .requireFeatures({"ANARI_KHR_GEOMETRY_CYLINDER", kMatte, kPerspective})
+      .registerInto(catalog);
+
+  // Camera inside the tube on its axis, looking at the p0 end: rays originate
+  // inside and must hit the interior lateral surface (far root). The caps
+  // permutation resolves the viewed end per spec: "first"/"both" close it (a
+  // cap seen from its back side), "none"/"second" leave the bore open to the
+  // background.
+  makeTest("geometry", "cylinder_interior")
+      .description(
+          "Checks cylinder intersection when the ray origin is inside the "
+          "tube (far-root interior-wall hits) across all spec cap modes.")
+      .build([](BuildContext &ctx) {
+        return litSurfaceWorld(ctx,
+            axisCylinder(ctx.device(),
+                float3(0.f, 0.f, -0.6f),
+                float3(0.f, 0.f, 0.6f),
+                0.3f,
+                ctx.getString("caps", "none").c_str()),
+            kEdgeLight);
+      })
+      .camera([](BuildContext &ctx, const scenes::Bounds &) {
+        return lookAtCamera(
+            ctx.device(), float3(0.f), float3(0.f, 0.f, -1.f), 1.2f, 0.001f);
+      })
+      .permute("caps", {"none", "first", "second", "both"})
+      .channels(kDepthOnly)
+      .requireFeatures({"ANARI_KHR_GEOMETRY_CYLINDER", kMatte, kPerspective})
+      .registerInto(catalog);
+
+  // View direction parallel to the cone axis from the base side, eye slightly
+  // off-axis: the base-cap rim is the whole silhouette (the cone only narrows
+  // behind it), so every spec caps value resolves visibly: "first"/"both"
+  // close the base (p0, the end facing the eye) with a face-on disc — the
+  // *_global_caps tests only ever see caps edge-on — while "none"/"second"
+  // open it onto the interior of the flank converging toward the apex.
+  makeTest("geometry", "cone_axis_view")
+      .description(
+          "Checks cone intersection with the view direction parallel to the "
+          "cone axis across all spec cap modes, viewed from the base.")
+      .build([](BuildContext &ctx) {
+        return litSurfaceWorld(ctx,
+            axisCone(ctx.device(),
+                float3(0.f, 0.f, -0.5f),
+                float3(0.f, 0.f, 0.5f),
+                0.4f,
+                ctx.getString("caps", "none").c_str()),
+            kEdgeLight);
+      })
+      .camera([](BuildContext &ctx, const scenes::Bounds &) {
+        return lookAtCamera(ctx.device(),
+            float3(0.1f, 0.05f, -2.f),
+            float3(0.f, 0.f, 1.f),
+            0.6f,
+            0.01f);
+      })
+      .permute("caps", {"none", "first", "second", "both"})
+      .channels(kColorDepth)
+      .requireFeatures({"ANARI_KHR_GEOMETRY_CONE", kMatte, kPerspective})
+      .registerInto(catalog);
+
+  // Camera on the cone axis beyond the apex, looking at the tip: rays near
+  // the axis converge on the zero-radius apex (apex singularity), and the
+  // whole visible flank is hit by near-axis-parallel rays — the cone's
+  // degenerate lateral-root case. caps stays at the spec default: the flank
+  // covers the full silhouette from this side, so no cap can be visible.
+  makeTest("geometry", "cone_apex_view")
+      .description(
+          "Checks cone intersection viewed head-on at the apex, where the "
+          "primitive radius goes to zero (apex singularity).")
+      .build([](BuildContext &ctx) {
+        return litSurfaceWorld(ctx,
+            axisCone(ctx.device(),
+                float3(0.f, 0.f, -0.5f),
+                float3(0.f, 0.f, 0.5f),
+                0.4f,
+                "none"),
+            kEdgeLight);
+      })
+      .camera([](BuildContext &ctx, const scenes::Bounds &) {
+        return lookAtCamera(ctx.device(),
+            float3(0.f, 0.f, 2.f),
+            float3(0.f, 0.f, -1.f),
+            0.6f,
+            0.01f);
+      })
+      .channels(kColorDepth)
+      .requireFeatures({"ANARI_KHR_GEOMETRY_CONE", kMatte, kPerspective})
+      .registerInto(catalog);
+
+  // Camera aimed at a sphere's limb so its silhouette runs across the frame: a
+  // wide band of primary rays is near-tangent (discriminant ~= 0), stressing
+  // grazing-ray robustness.
+  makeTest("geometry", "sphere_tangent")
+      .description(
+          "Checks sphere intersection for grazing rays near the silhouette "
+          "(near-zero discriminant).")
+      .build([](BuildContext &ctx) {
+        return litSurfaceWorld(
+            ctx, spheres(ctx.device(), {float3(0.f)}, {1.f}), kEdgeLight);
+      })
+      .camera([](BuildContext &ctx, const scenes::Bounds &) {
+        const float3 eye(0.f, 0.f, 3.5f);
+        const float3 at(0.95f, 0.f, 0.f);
+        return lookAtCamera(
+            ctx.device(), eye, math::normalize(at - eye), 0.5f, 0.01f);
+      })
+      .channels(kColorDepth)
+      .requireFeatures({"ANARI_KHR_GEOMETRY_SPHERE", kMatte, kPerspective})
       .registerInto(catalog);
 
   // ---- curve ----------------------------------------------------------------


### PR DESCRIPTION
Add six geometry tests stressing the intersector.
The tests encode spec-described behavior:

- sphere_interior: off-center origin-inside eye, far root against the
  interior wall, foreground ball for structure
- sphere_tangent: silhouette across the frame, near-zero discriminant
- cylinder_axis_view: near-axis-parallel rays down the bore across all
  four spec caps modes
- cylinder_interior: eye inside the tube, far-root interior-wall hits,
  all four caps modes resolved at the viewed end
- cone_axis_view: base cap face-on across all four caps modes
- cone_apex_view: apex singularity + near-parallel flank rays