### PR TITLE
cts: Add html report generation from `run` output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Rendering Backend (e.g., Embree for helide)
 - `generate_headers.py` — regenerates public C/C++ headers from the spec
 - Downstream devices invoke `anari_generate_queries()` in CMake (provided via the `code_gen` find_package component) rather than calling scripts directly.
 
-**`cts/`** — Conformance Test Suite. A self-contained C++ tool, `anariCts` (entry point `cts/src/main.cpp`, built with `BUILD_CTS=ON`), renders each test and scores it against generated ground truth; a thin Python reporting layer (`ctsReport.py`) reads the results. The harness/runner/Test definitions under `src/anari_test_scenes/cts/` compile into the internal static `anari_cts_core` target; `anariCts` and `anariCatalogTests` link that core. (The former pybind11/Python orchestration was removed.)
+**`cts/`** — Conformance Test Suite. A self-contained C++ tool, `anariCts` (entry point `cts/src/main.cpp`, built with `BUILD_CTS=ON`), renders each test, scores it against generated ground truth, and reports on the results tree (`report`: text and interactive HTML — ADR-0008); a thin Python layer (`ctsReport.py`) is retained only for a PDF. The harness/runner/Test definitions under `src/anari_test_scenes/cts/` compile into the internal static `anari_cts_core` target; `anariCts` and `anariCatalogTests` link that core. (The former pybind11/Python orchestration was removed.)
 
 ### Object Commit Model
 

--- a/cts/AGENTS.md
+++ b/cts/AGENTS.md
@@ -8,10 +8,11 @@ This file provides guidance to coding agents working in the CTS. See the parent
 
 The CTS (Conformance Test Suite) validates ANARI device implementations against
 a reference device (helide). It is a self-contained C++ command-line tool,
-`anariCts`, that renders each test *and* scores it against generated
-ground truth, plus a thin Python reporting layer (`ctsReport.py`) that only
-reads the results the tool writes. The two communicate through files only — there
-is no pybind11, no JSON scene format, and no Python orchestration (these were
+`anariCts`, that renders each test, scores it against generated ground truth,
+*and* reports on the results tree (`report`, ADR-0008). A thin Python
+layer (`ctsReport.py`) is retained only for the one output not worth porting to
+C++ — the `reportlab` PDF. Everything communicates through files only — there is
+no pybind11, no JSON scene format, and no Python orchestration (these were
 removed; see `docs/adr/0001`–`0002`).
 
 ## Build Commands
@@ -47,8 +48,9 @@ LD_LIBRARY_PATH="$PWD:$LD_LIBRARY_PATH" ./anariCatalogTests
 ```bash
 anariCts generate --workdir myrun      # ground truth from the reference device (helide)
 anariCts run helide --workdir myrun    # render + score a candidate against it
-python ../cts/ctsReport.py report myrun [--all] [--pdf out.pdf]
-python ../cts/ctsReport.py diff runA runB [--json]
+anariCts run rtx --workdir myrun -p ambientSample=4   # custom renderer params
+anariCts report myrun [--all] [--html out.html] [--embed]  # text + optional HTML
+python ../cts/ctsReport.py report myrun --pdf out.pdf      # PDF only
 
 anariCts list [--filter <pat>]         # enumerate the catalog
 anariCts query-features <device>       # device extensions
@@ -77,7 +79,8 @@ anariCts                 CLI dispatch: cts/src/main.cpp
   Runner                  build world -> render each Channel -> generate GT or score vs GT -> sidecar
   Metrics                 SSIM / PSNR (single source of metrics, ADR-0004)
   Workdir / Sidecar       results/ ground_truth/ assets/ tree; per-Case sidecar JSON (ADR-0003)
-ctsReport.py              reads the sidecar tree only; report + device diff
+  Report / HtmlReport     read the results tree -> text / HTML summary (ADR-0008)
+ctsReport.py              reads the results tree too; retained only for the PDF
 ```
 
 ### Key source files (`src/anari_test_scenes/cts/`)
@@ -102,11 +105,23 @@ ctsReport.py              reads the sidecar tree only; report + device diff
   supported per-Channel formats behind the shared map/unmap boundary.
 - `FrameFormats.{h,cpp}` — resolves a Case's per-Channel output `ANARIDataType`
   from its `frame_<channel>_type` axis (color/albedo/normal); pure + unit-tested.
+- `RendererParams.{h,cpp}` — pure parsing of CLI `--renderer-param NAME=VALUE`
+  overrides into ANARI-typed bytes (unit-tested). The runner resolves each
+  name's type from device introspection (falling back to inference) and sets it
+  on every Case's renderer before the Test's own `rendererConfig`, so it stays
+  device-agnostic and a renderer Test still wins on conflict.
 - `Metrics.{h,cpp}` / `Image.{h,cpp}` — SSIM/PSNR and PNG I/O (stb).
 - `Workdir.{h,cpp}` / `Sidecar.{h,cpp}` — the results tree layout and the
   versioned per-Case sidecar contract (carries the producing `device` identity
   since schema v2 plus optional Test descriptions; `Workdir` also keys the
-  per-channel diff/threshold images).
+  per-channel diff/threshold images). `Sidecar` both writes (`toJson`/
+  `writeSidecar`) and reads (`fromJson`/`readSidecar`) the contract.
+- `Report.{h,cpp}` — reads the results tree (`loadResults`), aggregates it
+  (`summarize`, `runDevice`), and emits the text summary. `kReportMetrics` is
+  the single list of reported metrics. Pure; unit-tested.
+- `HtmlReport.{h,cpp}` — renders the self-contained interactive HTML report
+  (inline CSS/JS, optional base64 `--embed`); pure `htmlEscape`/`base64Encode`
+  are unit-tested.
 - `GeometryLayout.{h,cpp}` — pure deterministic Layout generation using typed
   shape and primitive-mode enums.
 - `GeometryBuilder.{h,cpp}` — geometry-family specifications and ANARI
@@ -126,10 +141,12 @@ asset-scanning factory (gated on `ENABLE_GLTF`). `BuiltinTests.cpp` wires them
 all into the catalog.
 
 **Unit tests:** `tests/unit/test_cts_*.cpp` (catalog/expansion/filter/builder,
-metrics, results/sidecar/workdir, runner). Pure tests are tagged `[cts]`;
-device-backed ones add `[helide]` and self-skip if no device loads.
+metrics, results/sidecar/workdir, report/html, runner). Pure tests are
+tagged `[cts]`; device-backed ones add `[helide]` and self-skip if no device
+loads.
 
-**Python:** `ctsReport.py` — `report` and `diff` over the sidecar tree.
+**Python:** `ctsReport.py` — the `report --pdf` path only; it reads the results
+tree exactly as the C++ `report` does. Text and HTML live in C++.
 
 ## Extending the CTS
 
@@ -142,14 +159,17 @@ primary check, then declare axes, required features, and channels.
 it in `FrameFormats.cpp` (pure, unit-test it) and honor it in `Runner.cpp`.
 
 **New metric:** add it to `Metrics.{h,cpp}`, record it in the runner's
-`ChannelResult`, and add it to the `METRICS` list in `ctsReport.py` so reports
-and diffs surface it. There is exactly one metric implementation, in C++.
+`ChannelResult`, add it to `kReportMetrics` in `Report.h` (the C++ text/HTML),
+and to the `METRICS` list in `ctsReport.py` (the PDF). There is exactly one
+metric *implementation*, in C++; the two reported-metric lists are just display
+order for two independent readers of the one contract.
 
 **Sidecar schema change:** the sidecar is a versioned cross-language contract
-(ADR-0003). A purely incidental optional field (read with a default on the
-Python side) need not bump `kSidecarSchemaVersion`. Bump it when a change is
-either breaking *or* semantically significant to consumers — i.e. a field they
-should know to rely on — and update the Python reader in lockstep. v2 did the
-latter: it added the `device` object that the device-diff now keys runs on
-(plus the optional per-channel `diffImage`/`thresholdImage` debug paths), so the
-reader targets v2 and warns on older sidecars, prompting a regenerate.
+(ADR-0003) with two readers — the C++ `Sidecar` reader (`fromJson`) behind
+`report`, and `ctsReport.py` for the PDF. A purely incidental optional field
+(read with a default on both sides) need not bump `kSidecarSchemaVersion`. Bump
+it when a change is either breaking *or* semantically significant to consumers —
+i.e. a field they should know to rely on — and update both readers in lockstep.
+v2 did the latter: it added the `device` object that labels a run (plus the
+optional per-channel `diffImage`/`thresholdImage` debug paths), so the readers
+target v2 and warn on older sidecars, prompting a regenerate.

--- a/cts/CMakeLists.txt
+++ b/cts/CMakeLists.txt
@@ -1,10 +1,10 @@
 ## Copyright 2022-2026 The Khronos Group
 ## SPDX-License-Identifier: Apache-2.0
 
-# The CTS is a self-contained C++ tool (`anariCts`) plus a thin Python reporting
-# layer (ctsReport.py) that only reads the per-Case sidecar tree. The former
-# pybind/Python backend, the JSON scene format, and the orchestration scripts
-# have been removed.
+# The CTS is a self-contained C++ tool (`anariCts`) that renders, scores, and
+# reports on the results tree (report, ADR-0008); a thin Python layer
+# (ctsReport.py) is retained only for the PDF. The former pybind/Python backend,
+# the JSON scene format, and the orchestration scripts have been removed.
 #
 # The anariCts binary's entry point lives here (src/main.cpp). The CTS harness,
 # runner, and Test definitions it drives compile into the internal static

--- a/cts/CONTEXT.md
+++ b/cts/CONTEXT.md
@@ -2,8 +2,8 @@
 
 The CTS validates an ANARI device implementation by rendering a known battery of
 scenes and comparing the output against ground-truth images. This context covers
-the C++ test catalog, the C++ runner that executes it, and the Python layer that
-reports on and diffs runs.
+the C++ test catalog, the C++ runner that executes it, and the C++ reporting
+that summarizes runs (with a Python layer retained only for PDF).
 
 ## Language
 
@@ -54,18 +54,25 @@ _Avoid_: reference image, golden image, baseline
 A frame output buffer (color, depth, albedo, normal, primitive/object/instance
 id) that can be compared independently.
 
-**Manifest**:
-The machine-readable file the C++ runner writes for a run (which Cases ran, their
-pass/fail, metric scores, paths). The Python layer reads Manifests; it never
-renders.
-_Avoid_: results file, report
+**Sidecar**:
+The machine-readable JSON file the C++ runner writes next to a Case's images:
+which axis values it ran, its per-channel metric scores and pass/fail verdict,
+any skip reason, timing, image paths, and the producing device's identity. One
+per Case.
+_Avoid_: manifest, results file
+
+**Results tree**:
+The `results/` subtree of a Workdir — the full set of a run's Sidecars and
+images. It is the cross-language contract: every reader (the C++ `report`
+command and the Python PDF layer) consumes it by globbing, and none of them
+render or open a device.
+_Avoid_: manifest
 
 **Report**:
-The human-facing PDF the Python layer produces from one Manifest.
-
-**Device diff**:
-The Python comparison of two Candidates' Manifests/images against each other
-(parity), as distinct from comparing a Candidate against Ground truth (pass/fail).
+The human-facing summary of one run, produced by `anariCts report` from the
+Results tree: a text summary (default) or an interactive HTML report (`--html`).
+A PDF is an optional extra still produced by `ctsReport.py`.
+_Avoid_: manifest
 
 ### Tooling
 

--- a/cts/README.md
+++ b/cts/README.md
@@ -3,8 +3,8 @@
 The Conformance Test Suite (CTS) validates an ANARI device implementation by
 rendering a known battery of scenes and comparing each render against
 ground-truth images produced by a reference device (helide). It is a
-self-contained C++ command-line tool, `anariCts`, plus a thin Python reporting
-layer (`ctsReport.py`) that only reads the results the tool writes.
+self-contained C++ command-line tool, `anariCts`, with a thin Python layer
+(`ctsReport.py`) retained only for producing a PDF.
 
 It can:
 
@@ -13,7 +13,8 @@ It can:
 - render and score a candidate device against that ground truth (`run`),
 - report which extensions a device implements (`query-features`) and which
   tests it can run vs. will skip (`check-properties`),
-- summarize a run, optionally as a PDF, and diff two devices (`ctsReport.py`).
+- summarize a run as text or an interactive HTML report (`report`) — a PDF is
+  available via `ctsReport.py`.
 
 See [CONTEXT.md](CONTEXT.md) for the vocabulary (Test, Axis, Permutation,
 Variant, Case, Channel, Ground truth, Workdir, …) and `docs/adr/` for the design
@@ -23,15 +24,15 @@ decisions behind the architecture.
 
 ```
 anariCts  (C++ tool)                    renders + scores; writes results/ and ground_truth/
-    ↓ loads at runtime                   sidecar JSON + PNGs under a --workdir
-ANARI device (helide, or a candidate)
-    ↓ files only (ADR-0001)
-ctsReport.py  (Python)                   reads the results tree; report + device diff
+    │                                    sidecar JSON + PNGs under a --workdir
+    ├─ report                            reads the results tree -> text / HTML (ADR-0008)
+    └─ files only (ADR-0001)
+ctsReport.py  (Python)                   reads the same results tree; retained only for the PDF
 ```
 
-The C++ tool is the single source of image metrics (SSIM, PSNR); Python never
-opens a device and never re-computes a metric (ADR-0004). The two communicate
-only through the per-Case sidecar files in the workdir (ADR-0003).
+The C++ tool is the single source of image metrics (SSIM, PSNR); no reader ever
+opens a device or re-computes a metric (ADR-0004). Reporting reads the per-Case
+sidecar files in the workdir (ADR-0003); the results tree is the only contract.
 
 ## Building
 
@@ -58,9 +59,9 @@ for full coverage; without them, expect benign "Could not decode image" warnings
 (those Cases still pass, since ground truth and candidate are both rendered by
 the same device).
 
-The Python reporting layer needs only Python 3.9+, and `reportlab` *only* if you
-want a PDF — the text summary and the device diff have no third-party
-dependencies. See [pyproject.toml](pyproject.toml).
+The text summary and HTML report are built into `anariCts` and need nothing
+further. The Python layer is needed *only* for a PDF, and then only Python 3.9+
+plus `reportlab`. See [pyproject.toml](pyproject.toml).
 
 ## Usage
 
@@ -74,6 +75,7 @@ commands:
   query-features <device>    print the device's supported extensions
   query-metadata [options]   print catalog metadata as JSON
   check-properties <device>  report which tests the device can run vs. will skip
+  report <workdir>           summarize a run's results tree (text + optional HTML)
 
 options:
   --filter <pattern>   select a slice of the catalog (substring or glob over <category>/<test>)
@@ -95,6 +97,12 @@ options:
   --denoise            set the renderer denoise parameter
   --stdin              read newline-separated filter patterns from stdin (run)
   --verbose            print ANARI warnings
+
+report options:
+  --html <path>        also write an interactive HTML report
+  --embed              inline images in the HTML (portable single file; embeds
+                       only the initially-shown cases unless combined with --all)
+  --all                itemize every case (default: failures only)
 ```
 
 The library being tested must be loadable at runtime (on its
@@ -112,10 +120,11 @@ anariCts generate --renderer default --ambientRadiance 1 --workdir myrun
 # 2. Render + score a candidate device against it.
 anariCts run helide --renderer default --ambientRadiance 1 --workdir myrun
 
-# 3. Summarize the run (optionally as a PDF).
-python cts/ctsReport.py report myrun
-python cts/ctsReport.py report myrun --pdf myrun.pdf
-python cts/ctsReport.py report myrun --all --pdf myrun-all.pdf
+# 3. Summarize the run (text, or an interactive HTML report).
+anariCts report myrun
+anariCts report myrun --html myrun.html
+anariCts report myrun --all --embed --html myrun-all.html   # portable single file
+python cts/ctsReport.py report myrun --pdf myrun.pdf         # PDF, if you want one
 ```
 
 `run` exits non-zero if any Case failed, so it drops into CI directly.
@@ -167,34 +176,37 @@ anariCts query-metadata --filter frame    # descriptions and catalog metadata as
 device — a Test is skipped when the device is missing any of its required
 extensions.
 
-## Reporting and device diff
+## Reporting
 
-`ctsReport.py` reads a workdir's sidecar tree; it never renders.
+`anariCts report` reads a workdir's results tree; it never renders or opens a
+device (ADR-0008).
 
 ```bash
 # Summarize one run (per-category pass/fail/skip, plus failing Cases).
-python cts/ctsReport.py report myrun
-python cts/ctsReport.py report myrun --pdf myrun.pdf   # also embed failures in a PDF
-python cts/ctsReport.py report myrun --all --pdf myrun-all.pdf  # embed every Case
+anariCts report myrun
+anariCts report myrun --html myrun.html          # interactive HTML alongside the text
+anariCts report myrun --all --html myrun-all.html   # itemize every Case
+anariCts report myrun --all --embed --html myrun.html  # inline images: one portable file
 
-# Compare two candidates, each already run against the same ground truth.
-python cts/ctsReport.py diff runA runB
-python cts/ctsReport.py diff runA runB --json
+# A PDF is still available from the Python layer.
+python cts/ctsReport.py report myrun --pdf myrun.pdf
 ```
 
-A device diff is manifest arithmetic over the two sidecar trees — verdict
-differences, per-channel metric deltas, and cases present in only one run. It
-compares each device against the common ground truth; it does not re-compare
-pixels between the two devices (ADR-0004). `report` exits non-zero if any Case
-failed; `diff` exits non-zero if the two runs differ. Rendering duration is
-intentionally excluded from this semantic comparison, so timing-only changes do
-not produce differences or a non-zero exit status.
+`report` exits non-zero if any Case failed, so it drops into CI directly.
 
 By default, report details are limited to failed Cases. Pass `--all` to itemize
-passed, failed, and skipped Cases. Itemized PDF Cases include the Test's
-human-readable description; rendered Cases also include their metric scores and
-available candidate and ground-truth images. Text reports include the
-description under every itemized Case as well.
+passed, failed, and skipped Cases. The HTML report always carries every Case's
+metadata so its status filter and search work client-side; it defaults to a
+"failed first" ordering (with a synthetic Failed section) when the run has
+failures, and can switch back to grouping by category. With `--embed`, images
+travel inline as base64 for the initially-shown Cases only (add `--all` to embed
+everything), so a shared file stays bounded; without it, the HTML references the
+PNGs in the workdir. Each channel offers a result/ground-truth A/B flip (click
+or toggle) and an interactive difference-mask canvas — a threshold slider paints
+the exceeding pixels red, with an "over actual" toggle to see them on a dimmed
+render. (Reading diff pixels needs canvas-readable images: works with `--embed`
+or when served over http; a referenced `file://` diff falls back to the static
+image.)
 
 ## Comparison metrics
 

--- a/cts/README.md
+++ b/cts/README.md
@@ -85,6 +85,11 @@ options:
                        renderer subtype (default: default)
   --ambientRadiance <value>
                        baseline renderer ambientRadiance (default: 1)
+  -p, --renderer-param NAME=VALUE
+                       set a custom renderer parameter on every rendered case
+                       (repeatable; device-agnostic). VALUE parses into the
+                       renderer's device-declared type, else inferred as bool/
+                       int/float/float-vector/string. e.g. -p ambientSample=4
   --accumulation <n>   progressive color-channel frames when supported (default: 16)
   --no-accumulation    render each channel once
   --denoise            set the renderer denoise parameter
@@ -119,6 +124,15 @@ Use the same `--renderer` and `--ambientRadiance` values for `generate` and
 `run`; they are part of the rendering configuration being compared. The
 ambient value is a baseline for ordinary Tests. A renderer Test that explicitly
 exercises `ambientRadiance` overrides it with the Case's axis value.
+
+Pass device-specific renderer knobs with `-p/--renderer-param NAME=VALUE`
+(repeatable), e.g. `-p ambientSample=4`. It stays device-agnostic: the value is
+typed against the renderer subtype's device-declared parameter metadata (falling
+back to inference when the device does not report the parameter), so no
+device-specific names live in the CTS. Overrides apply over the baseline but
+before a renderer Test's own configuration, so such a Test still wins on
+conflict. As with `--ambientRadiance`, use the same overrides for `generate` and
+`run` when they affect the compared image.
 
 ### Running a slice
 

--- a/cts/ctsReport.py
+++ b/cts/ctsReport.py
@@ -2,17 +2,17 @@
 # Copyright 2021-2026 The Khronos Group
 # SPDX-License-Identifier: Apache-2.0
 
-"""CTS reporting and device-diff, driven entirely by the per-Case sidecar tree.
+"""CTS PDF report, driven entirely by the per-Case sidecar tree.
 
-The C++ `cts` runner renders and scores every Case and writes a per-Case sidecar
-JSON next to its images (ADR-0003). This module is the Python reporting layer
-(ADR-0001/0004): it only ever *reads* that tree — it never opens an ANARI device
-and never re-computes image metrics.
+Reporting is a C++ responsibility (ADR-0008): `anariCts report` emits the text
+summary and the interactive HTML report. This module is retained only for the
+one output not worth reproducing in C++ — the reportlab PDF. Like the C++
+reporter, it only ever *reads* the results tree the runner writes
+(ADR-0001/0003/0004); it never opens an ANARI device and never re-computes image
+metrics.
 
-Commands:
-  report <workdir> [--all] [--pdf report.pdf]
-                                        summarize one run; optional PDF.
-  diff <workdir_a> <workdir_b> [--json] compare two candidates' results.
+Command:
+  report <workdir> --pdf report.pdf [--all]   write a PDF from one run.
 
 The sidecar schema is versioned (schemaVersion); this reader targets version 2
 (which added the producing-device identity) and warns on a mismatch.
@@ -26,7 +26,8 @@ from pathlib import Path
 
 SCHEMA_VERSION = 2
 
-# Metrics shown in summaries/diffs, in display order.
+# Metrics shown in the PDF, in display order. The C++ reporters keep their own
+# copy (kReportMetrics); both are independent readers of the one contract.
 METRICS = ["ssim", "psnr"]
 
 
@@ -146,14 +147,6 @@ def summarize(results):
     return summary
 
 
-def channel_metric(data, channel, metric):
-    """A channel's metric score, or None if absent/non-finite."""
-    for ch in data.get("channels", []):
-        if ch.get("channel") == channel:
-            return ch.get("metrics", {}).get(metric)
-    return None
-
-
 def report_case_keys(results, include_all=False):
     """Case keys to itemize: every Case, or only failures by default."""
     if include_all:
@@ -161,139 +154,7 @@ def report_case_keys(results, include_all=False):
     return summarize(results)["failures"]
 
 
-def write_text_summary(workdir, results, out=sys.stdout, include_all=False):
-    s = summarize(results)
-    print(f"CTS report: {workdir}", file=out)
-    device = run_device(results)
-    if device:
-        print(
-            f"  device: {device.get('library')} "
-            f"({device.get('device', 'default')}/"
-            f"{device.get('renderer', 'default')})",
-            file=out,
-        )
-    print(
-        f"  {s['total']} cases: {s['passed']} passed, {s['failed']} failed, "
-        f"{s['skipped']} skipped",
-        file=out,
-    )
-    print("  by category:", file=out)
-    for cat, c in sorted(s["categories"].items()):
-        print(
-            f"    {cat:12s} {c['passed']:4d} passed  {c['failed']:4d} failed  "
-            f"{c['skipped']:4d} skipped",
-            file=out,
-        )
-    case_keys = report_case_keys(results, include_all)
-    if case_keys:
-        heading = "all cases" if include_all else "failed cases"
-        print(f"  {heading}:", file=out)
-        for key in case_keys:
-            data = results[key]
-            scores = []
-            for ch in data.get("channels", []):
-                vals = ", ".join(
-                    f"{m}={ch['metrics'].get(m)}" for m in METRICS if m in ch.get("metrics", {})
-                )
-                scores.append(f"{ch.get('channel')}({vals})")
-            # Cases with no channel scores (behavioral, or a failed render)
-            # carry their reason in detail or skipReason instead.
-            reason = data.get("detail") or data.get("skipReason", "")
-            summary_text = "; ".join(scores) if scores else reason
-            verdict = f" [{data.get('verdict', 'skipped')}]" if include_all else ""
-            print(f"    {key}{verdict}  {summary_text}", file=out)
-            description = data.get("description")
-            if isinstance(description, str) and description:
-                print(f"      Description: {description}", file=out)
-    return s
-
-
-# --- Device diff (ADR-0004) --------------------------------------------------
-
-
-def diff_results(results_a, results_b):
-    """Compare two candidates' sidecar trees.
-
-    Each is scored against the same ground truth, so a fair comparison is the
-    arithmetic of their sidecars: verdict differences, per-channel metric deltas
-    (b - a), and cases present in only one run. Duration deltas accompany Cases
-    with semantic changes but do not create changes on their own. This never
-    re-compares pixels.
-    """
-    keys = sorted(set(results_a) | set(results_b))
-    diff = {"only_in_a": [], "only_in_b": [], "verdict_changed": [], "cases": []}
-    for key in keys:
-        a = results_a.get(key)
-        b = results_b.get(key)
-        if a is None:
-            diff["only_in_b"].append(key)
-            continue
-        if b is None:
-            diff["only_in_a"].append(key)
-            continue
-        va, vb = a.get("verdict"), b.get("verdict")
-        entry = {"case": key, "verdict_a": va, "verdict_b": vb, "channels": []}
-        if va != vb:
-            diff["verdict_changed"].append(entry)
-        for metric in METRICS:
-            for ch in {c.get("channel") for c in a.get("channels", [])} | {
-                c.get("channel") for c in b.get("channels", [])
-            }:
-                ma = channel_metric(a, ch, metric)
-                mb = channel_metric(b, ch, metric)
-                delta = (mb - ma) if (isinstance(ma, (int, float)) and isinstance(mb, (int, float))) else None
-                if ma != mb:
-                    entry["channels"].append(
-                        {"channel": ch, "metric": metric, "a": ma, "b": mb, "delta": delta}
-                    )
-        ta, tb = a.get("durationMs", 0.0), b.get("durationMs", 0.0)
-        entry["durationDeltaMs"] = tb - ta
-        if entry["channels"] or va != vb:
-            diff["cases"].append(entry)
-    return diff
-
-
-def has_differences(diff):
-    """Whether a device diff contains any semantic result differences."""
-    return bool(
-        diff["only_in_a"]
-        or diff["only_in_b"]
-        or diff["verdict_changed"]
-        or any(entry["channels"] for entry in diff["cases"])
-    )
-
-
-def write_text_diff(name_a, name_b, diff, out=sys.stdout):
-    print(f"CTS device diff: A={name_a}  B={name_b}", file=out)
-    if diff["only_in_a"]:
-        print(f"  only in A ({len(diff['only_in_a'])}):", file=out)
-        for k in diff["only_in_a"]:
-            print(f"    {k}", file=out)
-    if diff["only_in_b"]:
-        print(f"  only in B ({len(diff['only_in_b'])}):", file=out)
-        for k in diff["only_in_b"]:
-            print(f"    {k}", file=out)
-    if diff["verdict_changed"]:
-        print(f"  verdict changed ({len(diff['verdict_changed'])}):", file=out)
-        for e in diff["verdict_changed"]:
-            print(f"    {e['case']}: {e['verdict_a']} -> {e['verdict_b']}", file=out)
-    metric_changes = [e for e in diff["cases"] if e["channels"]]
-    if metric_changes:
-        print(f"  metric deltas ({len(metric_changes)} cases):", file=out)
-        for e in metric_changes:
-            for c in e["channels"]:
-                d = c["delta"]
-                ds = f"{d:+.4f}" if isinstance(d, (int, float)) else "n/a"
-                print(
-                    f"    {e['case']} [{c['channel']}/{c['metric']}] "
-                    f"{c['a']} -> {c['b']} ({ds})",
-                    file=out,
-                )
-    if not has_differences(diff):
-        print("  no differences", file=out)
-
-
-# --- PDF report (optional; requires reportlab) -------------------------------
+# --- PDF report (requires reportlab) -----------------------------------------
 
 
 def generate_pdf(workdir, results, out_path, *, include_all=False):
@@ -315,7 +176,7 @@ def generate_pdf(workdir, results, out_path, *, include_all=False):
     except ImportError:
         print(
             "error: reportlab is not installed; cannot write a PDF "
-            "(text summary still works without --pdf)",
+            "(anariCts report gives text/HTML without it)",
             file=sys.stderr,
         )
         return False
@@ -452,47 +313,25 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_report = sub.add_parser("report", help="summarize one run's sidecar tree")
+    p_report = sub.add_parser("report", help="write a PDF from one run's sidecar tree")
     p_report.add_argument("workdir")
-    p_report.add_argument("--pdf", metavar="PATH", help="also write a PDF report")
+    p_report.add_argument("--pdf", metavar="PATH", required=True, help="PDF output path")
     p_report.add_argument(
         "--all",
         action="store_true",
-        help="itemize every case (PDF default: failed cases only)",
+        help="itemize every case (default: failed cases only)",
     )
-
-    p_diff = sub.add_parser("diff", help="compare two runs' sidecar trees")
-    p_diff.add_argument("workdir_a")
-    p_diff.add_argument("workdir_b")
-    p_diff.add_argument("--json", action="store_true", help="emit JSON instead of text")
 
     args = parser.parse_args(argv)
 
     if args.command == "report":
         results = load_results(args.workdir)
-        s = write_text_summary(args.workdir, results, include_all=args.all)
-        if args.pdf:
-            generate_pdf(
-                args.workdir, results, Path(args.pdf), include_all=args.all
-            )
-        return 1 if s["failed"] else 0
-
-    if args.command == "diff":
-        ra = load_results(args.workdir_a)
-        rb = load_results(args.workdir_b)
-        diff = diff_results(ra, rb)
-        # Label the two runs by their producing device (schema v2), falling
-        # back to the workdir name for pre-v2 sidecars.
-        label_a = device_label(ra, args.workdir_a)
-        label_b = device_label(rb, args.workdir_b)
-        diff["device_a"] = label_a
-        diff["device_b"] = label_b
-        if args.json:
-            json.dump(diff, sys.stdout, indent=2)
-            sys.stdout.write("\n")
-        else:
-            write_text_diff(label_a, label_b, diff)
-        return 1 if has_differences(diff) else 0
+        ok = generate_pdf(
+            args.workdir, results, Path(args.pdf), include_all=args.all
+        )
+        if not ok:
+            return 2
+        return 1 if summarize(results)["failed"] else 0
 
     return 2
 

--- a/cts/docs/adr/0008-reporting-is-a-cpp-responsibility.md
+++ b/cts/docs/adr/0008-reporting-is-a-cpp-responsibility.md
@@ -1,0 +1,30 @@
+# Reporting is a C++ responsibility; Python retains only PDF
+
+The text summary and interactive HTML report are produced by the `anariCts`
+tool itself (the `report` command) reading the results tree; the Python layer
+(`ctsReport.py`) is reduced to the one output that would be expensive to
+reproduce in C++ — the `reportlab` PDF. This makes the common reporting path
+python-free: a single binary generates and reports on a run.
+
+This reverses the earlier framing (ADR-0001) that Python is the reader and
+presenter. The files-only boundary still holds: the C++ report reads *its own
+output tree* (the per-Case sidecars, ADR-0003) and never loads a device, so
+reporting stays a pure, offline transform of the results tree — the same
+contract Python consumes. The split is drawn by cost, not by language: text and
+HTML are trivial string work in C++ (nlohmann::json is already vendored for
+reading), whereas a C++ PDF would pull in a heavyweight dependency for a
+rarely-needed output that a browser's "Print to PDF" over the HTML already
+covers.
+
+## Consequences
+
+- Aggregation exists in two places (C++ `Report` for text/HTML, Python for
+  PDF). Both are independent readers of the one contract (the results tree),
+  which ADR-0003 explicitly allows; the sidecar schema keeps them consistent.
+- A two-run device diff could follow the same pattern (read both trees, compare
+  sidecars) but is not implemented yet — reporting is scoped to a single run.
+- The list of reported metrics now lives in C++ (`kReportMetrics` in
+  `Report.h`); the Python PDF keeps its own copy for its own output.
+- The HTML report is self-contained (inline CSS/JS, no CDN) and can embed images
+  as base64 (`--embed`) for a portable single file; by default it references the
+  PNGs already in the workdir.

--- a/cts/pyproject.toml
+++ b/cts/pyproject.toml
@@ -1,13 +1,12 @@
 ## Copyright 2022-2026 The Khronos Group
 ## SPDX-License-Identifier: Apache-2.0
 
-# The CTS is a self-contained C++ tool (`cts`) that renders and scores; this
-# Python layer (ctsReport.py) only ever reads the results tree it writes — the
-# `report` and `diff` commands. Those use the standard library alone; the
-# optional PDF report is the layer's only third-party dependency, reportlab,
-# imported lazily. So nothing is required to run a text report or a device diff:
+# The CTS is a self-contained C++ tool (`anariCts`) that renders, scores, and
+# reports (text/HTML, ADR-0008). This Python layer (ctsReport.py) is
+# retained only for the PDF, which it renders from the results tree the tool
+# writes. Its one third-party dependency is reportlab, imported lazily:
 #
-#   pip install reportlab        # only needed for `ctsReport.py report --pdf`
+#   pip install reportlab        # required for `ctsReport.py report --pdf`
 #   pip install ".[pdf]"         # equivalent, from this directory
 
 [project]

--- a/cts/src/main.cpp
+++ b/cts/src/main.cpp
@@ -9,6 +9,7 @@
 #include "cts/Catalog.h"
 #include "cts/Expansion.h"
 #include "cts/HtmlReport.h"
+#include "cts/RendererParams.h"
 #include "cts/Report.h"
 #include "cts/Runner.h"
 #include "cts/Workdir.h"
@@ -59,6 +60,9 @@ struct Options
   uint32_t height = 256;
   std::string renderer = "default";
   float ambientRadiance = 1.f;
+  // Device-agnostic renderer parameter overrides (repeatable --renderer-param
+  // NAME=VALUE), applied to every rendered Case's renderer.
+  std::vector<RendererParam> rendererParams;
   bool useStdin = false;
   // query-device-info: restrict to an object type / subtype substring, list
   // subtypes only, or include detailed per-parameter info.
@@ -103,6 +107,11 @@ options:
                        renderer subtype (default: default)
   --ambientRadiance <value>
                        baseline renderer ambientRadiance (default: 1)
+  -p, --renderer-param NAME=VALUE
+                       set a custom renderer parameter on every rendered case
+                       (repeatable; device-agnostic). VALUE is parsed into the
+                       renderer's device-declared type, else inferred as bool/
+                       int/float/float-vector/string. e.g. -p ambientSample=4
   --accumulation <n>   progressive color-channel frames when the device supports
                        ANARI_KHR_FRAME_ACCUMULATION (default: 16; <=1 disables)
   --no-accumulation    render each channel once (equivalent to --accumulation 1)
@@ -181,7 +190,14 @@ Options parseOptions(int argc, char **argv, int start)
       o.renderer = next();
     else if (a == "--ambientRadiance")
       o.ambientRadiance = parseFloat(next(), o.ambientRadiance);
-    else if (a == "--accumulation")
+    else if (a == "--renderer-param" || a == "-p") {
+      const std::string spec = next();
+      if (auto p = parseRendererParam(spec))
+        o.rendererParams.push_back(*p);
+      else
+        std::cerr << "warning: ignoring malformed --renderer-param '" << spec
+                  << "' (expected NAME=VALUE)\n";
+    } else if (a == "--accumulation")
       o.accumulationFrames = parseDim(next(), o.accumulationFrames);
     else if (a == "--no-accumulation")
       o.accumulationFrames = 1;
@@ -416,6 +432,7 @@ int cmdGenerate(const Options &o)
   ro.ambientRadiance = o.ambientRadiance;
   ro.accumulationFrames = o.accumulationFrames;
   ro.denoise = o.denoise;
+  ro.rendererParams = o.rendererParams;
   ro.device = {deviceName, "default", o.renderer};
   Runner runner(d, Workdir(o.workdir), ro);
 
@@ -449,6 +466,7 @@ int cmdRun(const Options &o)
   ro.ambientRadiance = o.ambientRadiance;
   ro.accumulationFrames = o.accumulationFrames;
   ro.denoise = o.denoise;
+  ro.rendererParams = o.rendererParams;
   ro.device = {o.device, "default", o.renderer};
   Runner runner(d, Workdir(o.workdir), ro);
 

--- a/cts/src/main.cpp
+++ b/cts/src/main.cpp
@@ -8,6 +8,8 @@
 #include "cts/BuiltinTests.h"
 #include "cts/Catalog.h"
 #include "cts/Expansion.h"
+#include "cts/HtmlReport.h"
+#include "cts/Report.h"
 #include "cts/Runner.h"
 #include "cts/Workdir.h"
 // anari
@@ -18,6 +20,7 @@
 // std
 #include <cmath>
 #include <cstring>
+#include <fstream>
 #include <iostream>
 #include <limits>
 #include <set>
@@ -68,6 +71,12 @@ struct Options
   // value is the user-facing default; <=1 disables it.
   uint32_t accumulationFrames = 16;
   bool denoise = false;
+  // report: itemize every case, write an HTML file, and embed images in it.
+  // The positional arg holds the workdir.
+  bool includeAll = false;
+  bool embed = false;
+  std::string htmlOut;
+  std::vector<std::string> positionals;
 };
 
 void printUsage()
@@ -82,6 +91,7 @@ commands:
   query-metadata [options]   print catalog metadata as JSON
   query-device-info <device> introspect a device: object subtypes + parameter metadata
   check-properties <device>  report which tests the device can run vs. will skip
+  report <workdir>           summarize a run's results tree (text + optional HTML)
 
 options:
   --filter <pattern>   select a slice of the catalog (substring or glob over <category>/<test>)
@@ -100,6 +110,12 @@ options:
                        sets it, if the device lacks ANARI_KHR_RENDERER_DENOISE)
   --stdin              read newline-separated filter patterns from stdin (run)
   --verbose            print ANARI warnings
+
+report options:
+  --html <path>        also write an interactive HTML report
+  --embed              inline images in the HTML (portable single file; embeds
+                       only the initially-shown cases unless combined with --all)
+  --all                itemize every case (default: failures only)
 
 query-device-info options:
   --type <name>        restrict to object types whose name contains <name>
@@ -181,11 +197,19 @@ Options parseOptions(int argc, char **argv, int start)
       o.skipParameters = true;
     else if (a == "--info")
       o.info = true;
+    else if (a == "--all")
+      o.includeAll = true;
+    else if (a == "--embed")
+      o.embed = true;
+    else if (a == "--html")
+      o.htmlOut = next();
     else if (a == "--verbose")
       g_verbose = true;
-    else if (!a.empty() && a[0] != '-' && o.device.empty())
-      o.device = a; // positional <device>
-    else
+    else if (!a.empty() && a[0] != '-') {
+      o.positionals.push_back(a);
+      if (o.device.empty())
+        o.device = a; // first positional doubles as <device> for run/query
+    } else
       std::cerr << "warning: ignoring unknown argument '" << a << "'\n";
   }
   return o;
@@ -453,6 +477,31 @@ int cmdRun(const Options &o)
   return s.failed > 0 ? 1 : 0;
 }
 
+// Reporting reads the results tree only; it never loads a device (ADR-0008).
+int cmdReport(const Options &o)
+{
+  const std::string workdir =
+      o.positionals.empty() ? o.workdir : o.positionals.front();
+  auto results = loadResults(workdir, std::cerr);
+  writeTextSummary(std::cout, workdir, results, o.includeAll);
+
+  if (!o.htmlOut.empty()) {
+    HtmlOptions html;
+    html.includeAll = o.includeAll;
+    html.embed = o.embed;
+    html.htmlPath = o.htmlOut;
+    const std::string doc = generateHtml(workdir, results, html);
+    std::ofstream out(o.htmlOut, std::ios::binary);
+    if (!out || !(out << doc)) {
+      std::cerr << "error: failed to write HTML report '" << o.htmlOut << "'\n";
+      return 2;
+    }
+    std::cout << "wrote " << o.htmlOut << "\n";
+  }
+
+  return summarize(results).failed > 0 ? 1 : 0;
+}
+
 } // namespace
 
 int main(int argc, char **argv)
@@ -484,6 +533,8 @@ int main(int argc, char **argv)
     return cmdQueryDeviceInfo(o);
   if (command == "check-properties")
     return cmdCheckProperties(o);
+  if (command == "report")
+    return cmdReport(o);
 
   std::cerr << "error: unknown command '" << command << "'\n\n";
   printUsage();

--- a/cts/test_cts_report.py
+++ b/cts/test_cts_report.py
@@ -2,21 +2,21 @@
 # Copyright 2026 The Khronos Group
 # SPDX-License-Identifier: Apache-2.0
 
+# ctsReport.py is retained only for the PDF (ADR-0008); text summaries and the
+# device diff moved to the C++ `anariCts report`/`diff` and are covered by the
+# C++ tests (test_cts_report.cpp). These tests cover the shared sidecar-tree
+# reading the PDF path still depends on, plus PDF generation itself.
+
 import base64
 import contextlib
 import io
 import json
-import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from cts import ctsReport
-
-
-REPORT_SCRIPT = Path(__file__).with_name("ctsReport.py")
 
 
 def make_sidecar(
@@ -73,16 +73,7 @@ def write_sidecar_data(workdir, data, *, filename=None):
     return path
 
 
-def run_diff(run_a, run_b, *args):
-    return subprocess.run(
-        [sys.executable, REPORT_SCRIPT, "diff", run_a, run_b, *args],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-
-class ReportContractTests(unittest.TestCase):
+class SidecarLoadingTests(unittest.TestCase):
     def test_mixed_device_identities_are_diagnosed_and_not_mislabeled(self):
         results = {
             "geometry/triangle/a": make_sidecar(
@@ -154,74 +145,26 @@ class ReportContractTests(unittest.TestCase):
         self.assertIn("skipping unreadable sidecar", errors.getvalue())
         self.assertIn("has schemaVersion 1, expected 2", errors.getvalue())
 
-    def test_summary_covers_rendered_skipped_and_behavioral_cases(self):
+    def test_summarize_counts_rendered_skipped_and_behavioral_cases(self):
         failed = make_sidecar(case="failed", verdict="failed")
         skipped = make_sidecar(case="skipped", verdict="skipped")
         skipped["channels"] = []
-        skipped["skipReason"] = "missing feature"
-        behavioral = make_sidecar(
-            category="frame", test="callback", case="behavioral"
-        )
-        behavioral["channels"] = []
-        behavioral["detail"] = "frame completion callback fired"
         results = {
             "geometry/triangle/passed": make_sidecar(case="passed"),
             "geometry/triangle/failed": failed,
             "geometry/triangle/skipped": skipped,
-            "frame/callback/behavioral": behavioral,
         }
-        output = io.StringIO()
 
-        summary = ctsReport.write_text_summary("candidate", results, output)
+        summary = ctsReport.summarize(results)
 
-        self.assertEqual(summary["total"], 4)
-        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["total"], 3)
+        self.assertEqual(summary["passed"], 1)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["skipped"], 1)
         self.assertEqual(summary["failures"], ["geometry/triangle/failed"])
-        self.assertIn("4 cases: 2 passed, 1 failed, 1 skipped", output.getvalue())
 
-    def test_all_mode_lists_every_case_with_its_verdict(self):
-        skipped = make_sidecar(case="skipped", verdict="skipped")
-        skipped["channels"] = []
-        skipped["skipReason"] = "missing feature"
-        results = {
-            "geometry/triangle/passed": make_sidecar(case="passed"),
-            "geometry/triangle/failed": make_sidecar(
-                case="failed", verdict="failed"
-            ),
-            "geometry/triangle/skipped": skipped,
-        }
-        output = io.StringIO()
 
-        ctsReport.write_text_summary(
-            "candidate", results, output, include_all=True
-        )
-
-        text = output.getvalue()
-        self.assertIn("all cases:", text)
-        self.assertIn("geometry/triangle/passed [passed]", text)
-        self.assertIn("geometry/triangle/failed [failed]", text)
-        self.assertIn("geometry/triangle/skipped [skipped]", text)
-        self.assertIn("missing feature", text)
-
-    def test_text_report_includes_descriptions_for_itemized_cases(self):
-        results = {
-            "geometry/triangle/failed": make_sidecar(
-                case="failed",
-                verdict="failed",
-                description="Checks triangle geometry rendering.",
-            )
-        }
-        output = io.StringIO()
-
-        ctsReport.write_text_summary("candidate", results, output)
-
-        self.assertIn(
-            "Description: Checks triangle geometry rendering.",
-            output.getvalue(),
-        )
-
+class PdfReportTests(unittest.TestCase):
     def test_pdf_report_includes_descriptions_for_itemized_cases(self):
         try:
             from reportlab.platypus import Paragraph as real_paragraph
@@ -319,23 +262,11 @@ class ReportContractTests(unittest.TestCase):
             write_sidecar(workdir)
 
             with mock.patch.object(ctsReport, "generate_pdf") as generate_pdf:
-                with mock.patch.object(
-                    ctsReport,
-                    "write_text_summary",
-                    return_value={"failed": 0},
-                ) as write_text_summary:
-                    return_code = ctsReport.main(
-                        [
-                            "report",
-                            str(workdir),
-                            "--all",
-                            "--pdf",
-                            str(out_path),
-                        ]
-                    )
+                return_code = ctsReport.main(
+                    ["report", str(workdir), "--all", "--pdf", str(out_path)]
+                )
 
         self.assertEqual(return_code, 0)
-        self.assertTrue(write_text_summary.call_args.kwargs["include_all"])
         generate_pdf.assert_called_once()
         self.assertTrue(generate_pdf.call_args.kwargs["include_all"])
 
@@ -346,129 +277,13 @@ class ReportContractTests(unittest.TestCase):
             write_sidecar(workdir)
 
             with mock.patch.object(ctsReport, "generate_pdf") as generate_pdf:
-                with mock.patch.object(
-                    ctsReport,
-                    "write_text_summary",
-                    return_value={"failed": 0},
-                ) as write_text_summary:
-                    ctsReport.main(
-                        ["report", str(workdir), "--pdf", str(out_path)]
-                    )
+                ctsReport.main(["report", str(workdir), "--pdf", str(out_path)])
 
-        self.assertFalse(write_text_summary.call_args.kwargs["include_all"])
         self.assertFalse(generate_pdf.call_args.kwargs["include_all"])
 
-
-class DeviceDiffContractTests(unittest.TestCase):
-    def test_each_metric_change_is_a_semantic_difference(self):
-        baseline = {"geometry/triangle/default": make_sidecar()}
-        for metric in ("ssim", "psnr"):
-            with self.subTest(metric=metric):
-                changed = make_sidecar()
-                changed["channels"][0]["metrics"][metric] -= 0.05
-
-                diff = ctsReport.diff_results(
-                    baseline, {"geometry/triangle/default": changed}
-                )
-
-                self.assertTrue(ctsReport.has_differences(diff))
-                self.assertEqual(diff["cases"][0]["channels"][0]["metric"], metric)
-
-    def test_cli_exits_zero_for_identical_sidecars(self):
-        with tempfile.TemporaryDirectory() as temp:
-            run_a = Path(temp) / "run-a"
-            run_b = Path(temp) / "run-b"
-            write_sidecar(run_a)
-            write_sidecar(run_b)
-
-            result = run_diff(run_a, run_b)
-
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("no differences", result.stdout)
-
-    def test_missing_cases_and_verdict_changes_exit_one(self):
-        scenarios = ("missing", "verdict")
-        for scenario in scenarios:
-            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temp:
-                run_a = Path(temp) / "run-a"
-                run_b = Path(temp) / "run-b"
-                write_sidecar(run_a)
-                verdict = "failed" if scenario == "verdict" else "passed"
-                write_sidecar(run_b, verdict=verdict)
-                if scenario == "missing":
-                    write_sidecar(run_b, case="extra")
-
-                result = run_diff(run_a, run_b)
-
-            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-
-    def test_json_and_text_report_the_same_semantic_differences(self):
-        with tempfile.TemporaryDirectory() as temp:
-            run_a = Path(temp) / "run-a"
-            run_b = Path(temp) / "run-b"
-            write_sidecar(run_a, case="only-a")
-            write_sidecar(run_b, case="only-b")
-            write_sidecar(run_a, case="verdict")
-            write_sidecar(run_b, case="verdict", verdict="failed")
-            write_sidecar(run_a, case="metric", ssim=0.95)
-            write_sidecar(run_b, case="metric", ssim=0.90)
-
-            text_result = run_diff(run_a, run_b)
-            json_result = run_diff(run_a, run_b, "--json")
-
-        payload = json.loads(json_result.stdout)
-        expected_keys = {
-            *payload["only_in_a"],
-            *payload["only_in_b"],
-            *(entry["case"] for entry in payload["verdict_changed"]),
-            *(
-                entry["case"]
-                for entry in payload["cases"]
-                if entry["channels"]
-            ),
-        }
-        self.assertEqual(text_result.returncode, 1)
-        self.assertEqual(json_result.returncode, 1)
-        self.assertEqual(
-            expected_keys,
-            {
-                "geometry/triangle/only-a",
-                "geometry/triangle/only-b",
-                "geometry/triangle/verdict",
-                "geometry/triangle/metric",
-            },
-        )
-        for key in expected_keys:
-            self.assertIn(key, text_result.stdout)
-
-    def test_timing_only_change_is_not_a_semantic_difference(self):
-        with tempfile.TemporaryDirectory() as temp:
-            run_a = Path(temp) / "run-a"
-            run_b = Path(temp) / "run-b"
-            write_sidecar(run_a, duration_ms=10.0)
-            write_sidecar(run_b, duration_ms=25.0)
-
-            diff = ctsReport.diff_results(
-                ctsReport.load_results(run_a), ctsReport.load_results(run_b)
-            )
-            result = run_diff(run_a, run_b)
-
-        self.assertFalse(ctsReport.has_differences(diff))
-        self.assertEqual(diff["cases"], [])
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("no differences", result.stdout)
-
-    def test_cli_exits_one_for_metric_only_change(self):
-        with tempfile.TemporaryDirectory() as temp:
-            run_a = Path(temp) / "run-a"
-            run_b = Path(temp) / "run-b"
-            write_sidecar(run_a, ssim=0.95)
-            write_sidecar(run_b, ssim=0.90)
-
-            result = run_diff(run_a, run_b)
-
-        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-        self.assertIn("geometry/triangle/default [color/ssim]", result.stdout)
+    def test_pdf_output_path_is_required(self):
+        with self.assertRaises(SystemExit):
+            ctsReport.main(["report", "somewhere"])
 
 
 if __name__ == "__main__":

--- a/src/anari_test_scenes/CMakeLists.txt
+++ b/src/anari_test_scenes/CMakeLists.txt
@@ -106,6 +106,7 @@ if (BUILD_CTS OR BUILD_TESTING)
     cts/LightBuilder.cpp
     cts/Metrics.cpp
     cts/ParameterBinding.cpp
+    cts/RendererParams.cpp
     cts/Report.cpp
     cts/Runner.cpp
     cts/Sidecar.cpp

--- a/src/anari_test_scenes/CMakeLists.txt
+++ b/src/anari_test_scenes/CMakeLists.txt
@@ -100,11 +100,13 @@ if (BUILD_CTS OR BUILD_TESTING)
     cts/FrameReadback.cpp
     cts/GeometryBuilder.cpp
     cts/GeometryLayout.cpp
+    cts/HtmlReport.cpp
     cts/Image.cpp
     cts/InstanceBuilder.cpp
     cts/LightBuilder.cpp
     cts/Metrics.cpp
     cts/ParameterBinding.cpp
+    cts/Report.cpp
     cts/Runner.cpp
     cts/Sidecar.cpp
     cts/SamplerBuilder.cpp

--- a/src/anari_test_scenes/cts/Channel.h
+++ b/src/anari_test_scenes/cts/Channel.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace anari {
 namespace cts {
 
@@ -37,6 +39,25 @@ inline const char *channelName(Channel c)
     return "instanceId";
   }
   return "unknown";
+}
+
+// Inverse of channelName; defaults to Color for an unknown name so a
+// best-effort read of an older or foreign sidecar still yields a Channel.
+inline Channel channelFromName(const std::string &name)
+{
+  if (name == "depth")
+    return Channel::Depth;
+  if (name == "albedo")
+    return Channel::Albedo;
+  if (name == "normal")
+    return Channel::Normal;
+  if (name == "primitiveId")
+    return Channel::PrimitiveId;
+  if (name == "objectId")
+    return Channel::ObjectId;
+  if (name == "instanceId")
+    return Channel::InstanceId;
+  return Channel::Color;
 }
 
 } // namespace cts

--- a/src/anari_test_scenes/cts/HtmlReport.cpp
+++ b/src/anari_test_scenes/cts/HtmlReport.cpp
@@ -1,0 +1,1024 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "HtmlReport.h"
+
+#include "Report.h"
+// std
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace anari {
+namespace cts {
+
+namespace {
+
+// Inline stylesheet. Neutral light theme, self-contained: system font stack
+// (no @font-face), no external resources, so the document stays portable
+// offline and when embedded. Accent is a generic blue; green/red/grey carry the
+// pass/fail/skip semantics.
+constexpr const char *kStyle = R"CSS(
+:root {
+  color-scheme: light;
+  --bg: #eef1f4; --fg: #1b2127; --card: #ffffff; --panel: #f6f8fa;
+  --border: #e3e8ec; --border-soft: #edf0f3; --thead: #f3f6f8;
+  --muted: #5f6b74; --muted2: #66727b; --muted3: #7a848d; --dark: #333c44;
+  --accent: #487a90; --accent-hover: #3a6478;
+  --pass: #1a7f37; --fail: #cf222e; --skip: #6e7781; --link: #487a90;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+* { box-sizing: border-box; }
+[hidden] { display: none !important; } /* beat element display rules (e.g. flex) */
+html, body {
+  margin: 0; background: var(--bg); color: var(--fg);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+img { display: block; }
+a { color: var(--link); text-decoration: none; }
+a:hover { color: var(--accent-hover); text-decoration: underline; }
+.kmono { font-family: var(--mono); }
+.wrap { max-width: 1200px; margin: 0 auto; padding: 0 32px 90px; }
+
+/* header */
+header {
+  display: flex; align-items: center; justify-content: space-between; gap: 24px;
+  padding: 26px 0 22px; border-bottom: 1px solid var(--border); flex-wrap: wrap;
+}
+.brand { display: flex; align-items: center; gap: 14px; }
+.logo { height: 30px; width: auto; color: var(--accent); flex: none; }
+.title { font-size: 19px; font-weight: 700; letter-spacing: -.01em; }
+.subtitle { font-size: 13px; color: var(--muted); }
+.runbox { font-size: 12px; color: var(--muted2); text-transform: uppercase;
+  letter-spacing: .06em; text-align: right; }
+
+/* summary */
+.summary {
+  display: grid; grid-template-columns: 300px 1fr; gap: 24px; margin-top: 26px;
+  align-items: stretch;
+}
+.ring-card {
+  background: linear-gradient(180deg, #fff, #f4f7f9); border: 1px solid var(--border);
+  border-radius: 14px; padding: 22px 24px; display: flex; align-items: center;
+  gap: 22px;
+}
+.ring { position: relative; width: 104px; height: 104px; flex: none;
+  border-radius: 50%; display: flex; align-items: center; justify-content: center; }
+.ring .hole {
+  width: 78px; height: 78px; border-radius: 50%; background: #fff; display: flex;
+  flex-direction: column; align-items: center; justify-content: center;
+}
+.ring .pct { font-size: 26px; font-weight: 700; line-height: 1; }
+.ring .pct span { font-size: 14px; color: var(--muted); }
+.ring .cap { font-size: 10.5px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: .05em; margin-top: 3px; }
+.legend { display: flex; flex-direction: column; gap: 9px; }
+.legend .row { display: flex; align-items: center; gap: 8px; font-size: 13px;
+  color: var(--dark); }
+.legend .dot { width: 9px; height: 9px; border-radius: 2px; }
+.legend .n { margin-left: auto; font-weight: 600; }
+.stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+.stat {
+  background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+  padding: 16px 18px; display: flex; flex-direction: column; gap: 6px;
+}
+.stat .k { font-size: 11px; color: var(--accent); text-transform: uppercase;
+  letter-spacing: .06em; font-weight: 600; }
+.stat .v { font-size: 24px; font-weight: 700; }
+.stat .v.sm { font-size: 16px; font-weight: 600; margin-top: 4px; }
+.stat .sub { font-size: 11.5px; color: var(--muted); }
+
+/* toolbar */
+.toolbar { display: flex; align-items: center; gap: 16px; margin-top: 28px;
+  flex-wrap: wrap; }
+.search { position: relative; flex: 1; min-width: 240px; max-width: 360px; }
+.search svg { position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+  color: var(--muted); }
+.search input {
+  width: 100%; height: 32px; padding: 0 10px 0 32px; font: inherit; font-size: 13px;
+  border: 1px solid var(--border); border-radius: 6px; background: #fff;
+  color: var(--fg);
+}
+.segmented, .segctl { display: flex; border: 1px solid var(--border);
+  border-radius: 6px; overflow: hidden; background: #fff; }
+.segctl button {
+  font: inherit; font-size: 12.5px; padding: 6px 12px; cursor: pointer;
+  border: none; background: none; color: var(--muted);
+  border-left: 1px solid var(--border);
+}
+.segctl button:first-child { border-left: none; }
+.segctl button.active { background: var(--accent); color: #fff; font-weight: 600; }
+.showing { margin-left: auto; font-size: 13px; color: var(--muted); }
+
+/* groups */
+.group-head { display: flex; align-items: center; gap: 12px; margin: 26px 0 8px;
+  scroll-margin-top: 20px; }
+.group-head .name { font-size: 13px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .09em; color: #566370; }
+.group-head .rule { height: 1px; flex: 1; background: var(--border); }
+.group-head .pfs { display: flex; gap: 6px; font-size: 11.5px; }
+.group-head.fail-head .name { color: var(--fail); }
+.group-head.fail-head .rule { background: var(--fail); opacity: .25; }
+
+/* test rows */
+.test { border: 1px solid var(--border); border-radius: 11px; margin-bottom: 8px;
+  overflow: hidden; background: #fff; }
+.test .row {
+  display: grid; grid-template-columns: 104px 1fr 232px 96px 20px; align-items: center;
+  gap: 16px; padding: 13px 18px; cursor: pointer;
+}
+.test .row:hover { background: #f1f5f8; }
+.badge { display: inline-flex; align-items: center; padding: 2px 10px;
+  border-radius: 5px; font-size: 11.5px; font-weight: 600; color: #fff; }
+.badge.passed { background: var(--pass); }
+.badge.failed { background: var(--fail); }
+.badge.skipped { background: var(--skip); }
+.test .name { font-family: var(--mono); font-size: 14px; font-weight: 600;
+  color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.test .desc { font-size: 12px; color: var(--muted); white-space: nowrap;
+  overflow: hidden; text-overflow: ellipsis; margin-top: 2px; }
+.test .metric { font-family: var(--mono); font-size: 12.5px; }
+.test .dur { font-family: var(--mono); font-size: 12.5px; color: var(--muted);
+  text-align: right; }
+.test .chev { color: #7a848d; font-size: 15px; transition: transform .18s ease; }
+.test.open .chev { transform: rotate(90deg); }
+
+/* expanded panel */
+.panel { display: none; border-top: 1px solid var(--border); padding: 20px 18px 22px;
+  background: var(--panel); }
+.test.open .panel { display: block; animation: rowIn .2s ease; }
+@keyframes rowIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+.compare { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.pane-head { display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 10px; }
+.pane-head .lbl { font-size: 11px; color: var(--muted2); text-transform: uppercase;
+  letter-spacing: .07em; }
+.stage { position: relative; border: 1px solid var(--border); border-radius: 9px;
+  overflow: hidden; background: #000; cursor: pointer; aspect-ratio: 1 / 1; }
+.stage .layer { position: absolute; inset: 0; width: 100%; height: 100%;
+  object-fit: contain; display: none; }
+.stage[data-ab=result] .layer[data-role=result],
+.stage[data-ab=reference] .layer[data-role=groundTruth] { display: block; }
+.tag { position: absolute; top: 9px; left: 9px; padding: 3px 9px; border-radius: 5px;
+  font-size: 10.5px; font-weight: 600; letter-spacing: .03em; color: #fff; display: none; }
+.stage[data-ab=result] .tag.actual { display: block; background: rgba(208,50,74,.85); }
+.stage[data-ab=reference] .tag.reference { display: block; background: rgba(72,122,144,.85); }
+.cap-line { font-size: 11px; color: var(--muted3); margin-top: 7px; text-align: center; }
+.maskbox { position: relative; border: 1px solid var(--border); border-radius: 9px;
+  overflow: hidden; background: #000; aspect-ratio: 1 / 1; }
+.maskcanvas, .maskfallback { width: 100%; height: 100%; display: block;
+  object-fit: contain; image-rendering: pixelated; }
+.threshrow { display: flex; align-items: center; gap: 10px; margin-top: 8px;
+  font-size: 11.5px; color: var(--muted); }
+.threshrow .tlabel { text-transform: uppercase; letter-spacing: .05em; }
+.threshrow input[type=range] { flex: 1; accent-color: var(--fail); }
+.threshrow .tval { color: var(--dark); min-width: 2.6em; text-align: right; }
+.overtoggle { display: flex; align-items: center; gap: 5px; font-size: 11.5px;
+  color: var(--muted); cursor: pointer; }
+.overtoggle input { accent-color: var(--accent); }
+.abseg { font: inherit; font-size: 10.5px; padding: 2px 9px; cursor: pointer;
+  border: 1px solid var(--border); background: #fff; color: var(--muted); }
+.abseg:first-child { border-radius: 4px 0 0 4px; }
+.abseg:last-child { border-radius: 0 4px 4px 0; border-left: none; }
+.abseg.active { background: var(--accent); color: #fff; font-weight: 600;
+  border-color: var(--accent); }
+.skipnote { grid-column: 1 / -1; display: flex; align-items: center; gap: 12px;
+  padding: 22px; border: 1px dashed #ccd3da; border-radius: 9px; background: #fff; }
+.skipnote .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--skip);
+  flex: none; }
+.skipnote .h { font-size: 13px; font-weight: 600; color: var(--dark); }
+.skipnote .r { font-size: 12.5px; color: var(--muted); margin-top: 3px; }
+
+/* metrics + config tables */
+.meta { display: grid; grid-template-columns: 1.3fr 1fr; gap: 22px; margin-top: 20px; }
+.meta .lbl { font-size: 11px; color: var(--muted2); text-transform: uppercase;
+  letter-spacing: .07em; margin-bottom: 9px; }
+.tbl { border: 1px solid var(--border); border-radius: 9px; overflow: hidden; }
+.tbl .thead, .tbl .trow { display: grid; grid-template-columns: 1fr 1fr 1fr 70px;
+  padding: 9px 14px; align-items: center; }
+.tbl .thead { background: var(--thead); font-size: 10.5px; color: var(--muted2);
+  text-transform: uppercase; letter-spacing: .05em; }
+.tbl .trow { border-top: 1px solid var(--border-soft); font-size: 12.5px; }
+.tbl .trow .res { text-align: right; font-weight: 600; }
+.cfg { display: flex; flex-direction: column; border: 1px solid var(--border);
+  border-radius: 9px; overflow: hidden; }
+.cfg .r { display: flex; justify-content: space-between; gap: 16px; padding: 9px 14px;
+  font-size: 12.5px; }
+.cfg .r + .r { border-top: 1px solid var(--border-soft); }
+.cfg .r .kk { color: var(--muted); flex: none; }
+.cfg .r .vv { font-family: var(--mono); color: var(--dark); overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; }
+.pass-fg { color: var(--pass); } .fail-fg { color: var(--fail); }
+.skip-fg { color: var(--muted2); } .dark-fg { color: var(--dark); }
+.no-images { color: var(--muted3); font-size: 12px; font-style: italic;
+  padding: 20px; text-align: center; border: 1px dashed #ccd3da; border-radius: 9px;
+  background: #fff; grid-column: 1 / -1; }
+.empty { text-align: center; padding: 70px 20px; color: var(--muted3); }
+.empty .h { font-size: 15px; font-weight: 600; color: #9aa4ad; }
+.empty .s { font-size: 13px; margin-top: 6px; }
+)CSS";
+
+// Client behavior: status + text filtering, row expand/collapse, A/B reference
+// vs. actual flip, and diff/threshold mask toggle. No dependencies.
+constexpr const char *kScript = R"JS(
+const list = document.getElementById('list');
+const failHead = document.getElementById('failed-head');
+const rows = Array.from(list.querySelectorAll('.test'));
+const original = Array.from(list.children);
+const origIndex = new Map(original.map((el, i) => [el, i]));
+const search = document.getElementById('search');
+const statusSegs = Array.from(document.querySelectorAll('.statusseg'));
+const sortSegs = Array.from(document.querySelectorAll('.sortseg'));
+let status = 'all';
+const activeSort = document.querySelector('.sortseg.active');
+let sort = activeSort ? activeSort.dataset.sort : 'category';
+
+// Arrange the DOM for the active sort. "failed first" lifts failed rows into a
+// prepended "Failed" section, then keeps the remaining rows under their own
+// category headers; "category" restores the natural grouped order (the Failed
+// section header then has no rows before the first category and hides itself).
+function layout() {
+  if (sort === 'failed') {
+    const failed = rows.filter(r => r.dataset.verdict === 'failed')
+      .sort((a, b) => origIndex.get(a) - origIndex.get(b));
+    const rest = original.filter(el => el !== failHead
+      && !(el.classList.contains('test') && el.dataset.verdict === 'failed'));
+    list.appendChild(failHead);
+    failed.forEach(r => list.appendChild(r));
+    rest.forEach(el => list.appendChild(el));
+  } else {
+    original.forEach(el => list.appendChild(el));
+  }
+}
+
+function applyFilter() {
+  layout();
+
+  const q = search.value.trim().toLowerCase();
+  let shown = 0;
+  for (const r of rows) {
+    const ok = (status === 'all' || r.dataset.verdict === status)
+      && (!q || r.dataset.search.includes(q));
+    r.hidden = !ok;
+    if (ok) shown++;
+  }
+
+  // Each header's P/F/S counts reflect only the rows currently shown under it,
+  // and the header hides when it has none — in whatever order is current.
+  let head = null, p = 0, f = 0, s = 0;
+  const flush = () => {
+    if (!head) return;
+    const set = (k, v, suffix) => {
+      const e = head.querySelector('[data-c=' + k + ']');
+      if (e) e.textContent = v + suffix;
+    };
+    set('p', p, 'P'); set('f', f, 'F'); set('s', s, 'S');
+    head.hidden = p + f + s === 0;
+  };
+  for (const el of Array.from(list.children)) {
+    if (el.classList.contains('group-head')) { flush(); head = el; p = f = s = 0; }
+    else if (el.classList.contains('test') && !el.hidden) {
+      const v = el.dataset.verdict;
+      if (v === 'passed') p++; else if (v === 'failed') f++; else s++;
+    }
+  }
+  flush();
+
+  document.getElementById('shown').textContent = shown;
+  document.getElementById('noresults').hidden = shown > 0;
+}
+statusSegs.forEach(b => b.addEventListener('click', () => {
+  status = b.dataset.status;
+  statusSegs.forEach(x => x.classList.toggle('active', x === b));
+  applyFilter();
+}));
+sortSegs.forEach(b => b.addEventListener('click', () => {
+  sort = b.dataset.sort;
+  sortSegs.forEach(x => x.classList.toggle('active', x === b));
+  applyFilter();
+}));
+search.addEventListener('input', applyFilter);
+
+// Expand / collapse a test row; initialize its difference-mask canvases the
+// first time it opens (lazy — most rows are never expanded).
+document.querySelectorAll('.test .row').forEach(row => {
+  row.addEventListener('click', () => {
+    const test = row.closest('.test');
+    if (test.classList.toggle('open'))
+      test.querySelectorAll('.mask-pane').forEach(initMask);
+  });
+});
+
+// A/B flip between reference (ground truth) and actual (this run).
+function setAB(stage, v) {
+  stage.dataset.ab = v;
+  const compare = stage.closest('.compare-pane');
+  compare.querySelectorAll('.abseg').forEach(
+    b => b.classList.toggle('active', b.dataset.ab === v));
+}
+document.querySelectorAll('.stage').forEach(stage => {
+  stage.addEventListener('click',
+    () => setAB(stage, stage.dataset.ab === 'result' ? 'reference' : 'result'));
+});
+document.querySelectorAll('.abseg').forEach(b => b.addEventListener('click', () => {
+  setAB(b.closest('.compare-pane').querySelector('.stage'), b.dataset.ab);
+}));
+
+// Interactive difference-mask: threshold the diff image live and paint the
+// exceeded pixels red, optionally over a dimmed actual render.
+function renderMask(p) {
+  const ctx = p._ctx, w = p._w, h = p._h;
+  ctx.clearRect(0, 0, w, h);
+  if (p._over.checked && p._actual) {
+    ctx.drawImage(p._actual, 0, 0, w, h);
+    ctx.fillStyle = 'rgba(255,255,255,0.65)';
+    ctx.fillRect(0, 0, w, h);
+  } else {
+    ctx.fillStyle = '#111';
+    ctx.fillRect(0, 0, w, h);
+  }
+  const t = +p._slider.value, src = p._diff.data, m = p._mask.data;
+  for (let i = 0; i < src.length; i += 4) {
+    if (Math.max(src[i], src[i + 1], src[i + 2]) > t) {
+      m[i] = 255; m[i + 1] = 0; m[i + 2] = 0; m[i + 3] = 255;
+    } else {
+      m[i + 3] = 0;
+    }
+  }
+  p._maskCtx.putImageData(p._mask, 0, 0);
+  ctx.drawImage(p._maskCanvas, 0, 0, w, h);
+}
+function initMask(pane) {
+  if (pane._init) return;
+  pane._init = true;
+  const canvas = pane.querySelector('.maskcanvas');
+  if (!canvas) return;
+  const slider = pane.querySelector('.threshslider');
+  const tval = pane.querySelector('.tval');
+  const over = pane.querySelector('.over-actual');
+  const img = new Image();
+  img.onload = () => {
+    const w = img.naturalWidth, h = img.naturalHeight;
+    const off = document.createElement('canvas');
+    off.width = w; off.height = h;
+    const octx = off.getContext('2d');
+    octx.drawImage(img, 0, 0);
+    let diff;
+    try {
+      diff = octx.getImageData(0, 0, w, h);
+    } catch (e) {
+      // Canvas tainted (referenced file:// diff) — fall back to the static image.
+      const fb = document.createElement('img');
+      fb.className = 'maskfallback';
+      fb.src = canvas.dataset.diff;
+      fb.alt = 'difference';
+      canvas.replaceWith(fb);
+      slider.disabled = true;
+      over.disabled = true;
+      slider.title = 'interactive thresholding needs an embedded (--embed) report';
+      return;
+    }
+    canvas.width = w; canvas.height = h;
+    pane._ctx = canvas.getContext('2d');
+    pane._w = w; pane._h = h;
+    pane._diff = diff;
+    pane._maskCanvas = document.createElement('canvas');
+    pane._maskCanvas.width = w; pane._maskCanvas.height = h;
+    pane._maskCtx = pane._maskCanvas.getContext('2d');
+    pane._mask = pane._maskCtx.createImageData(w, h);
+    pane._slider = slider;
+    pane._over = over;
+    slider.addEventListener('input', () => { tval.textContent = slider.value; renderMask(pane); });
+    over.addEventListener('change', () => renderMask(pane));
+    // Reuse the sibling A/B "actual" image for the dimmed background.
+    const actualEl = pane.closest('.compare').querySelector('.layer[data-role=result]');
+    if (actualEl && actualEl.src) {
+      const ai = new Image();
+      ai.onload = () => { pane._actual = ai; if (over.checked) renderMask(pane); };
+      ai.src = actualEl.src;
+    }
+    renderMask(pane);
+  };
+  img.src = canvas.dataset.diff;
+}
+
+applyFilter();
+)JS";
+
+// The ANARI wordmark (Khronos ANARI-Docs logo), inlined so the header stays
+// self-contained. Fills use currentColor so the header can tint it with the
+// accent (ANARI teal).
+constexpr const char *kAnariLogo =
+    R"SVG(<svg class="logo" viewBox="0 0 1500 500" role="img" aria-label="ANARI" xmlns="http://www.w3.org/2000/svg"><g><g><polygon fill="currentColor" points="1199.5,415.8 1191.4,415.8 1191.4,436.8 1184.4,436.8 1184.4,415.8 1176.3,415.8 1176.3,409.8 1199.5,409.8 "/><polygon fill="currentColor" points="1202.6,409.8 1213,409.8 1217.6,427.8 1217.7,427.8 1222.4,409.8 1232.7,409.8 1232.7,436.8 1226.1,436.8 1226.1,416.3 1226,416.3 1220.4,436.8 1215,436.8 1209.3,416.3 1209.2,416.3 1209.2,436.8 1202.6,436.8 "/></g><g><path fill="currentColor" d="M183.8,244.5h78.4l82.7,192.4h-68.7l-11.6-31.3h-84.1L169,436.8h-68.7L183.8,244.5z M222.9,292.9h-0.5 l-26.7,72.7h53.9L222.9,292.9z"/><path fill="currentColor" d="M354.1,244.5h73.8l89.2,120.4h0.5V244.5h62v192.4h-70.9l-92.1-121.5H416v121.5h-62V244.5H354.1z"/><path fill="currentColor" d="M672.2,244.5h78.4l82.7,192.4h-68.7L753,405.6h-84l-11.6,31.3h-68.7L672.2,244.5z M711.3,292.9h-0.5 l-26.7,72.7H738L711.3,292.9z"/><path fill="currentColor" d="M842.5,244.5h154.1c11.9,0,21.9,1.3,30,3.9c8.2,2.6,14.8,6.2,19.9,10.9c5.1,4.7,8.8,10.3,11,16.8 c2.2,6.6,3.4,13.9,3.4,22c0,12.9-3,22.9-8.9,30s-13.2,11.7-21.8,13.9v0.5c6.1,2,11.3,5.6,15.5,10.9s6.8,13.2,7.7,23.6 c0.7,9.5,1.4,17.5,2,24s1.3,12,2.2,16.6c0.8,4.6,1.8,8.4,3.1,11.3c1.3,3,2.9,5.6,4.9,7.9h-70.3c-1.8-4.1-2.9-8.8-3.2-14 c-0.4-5.2-0.5-10.1-0.5-14.5c0-7.5-0.6-13.6-1.8-18.3c-1.2-4.7-2.9-8.3-5.3-10.8c-2.3-2.5-5.1-4.2-8.4-5.1 c-3.2-0.9-6.8-1.3-10.8-1.3h-58.7v64.1h-64.1L842.5,244.5L842.5,244.5z M906.6,329.6h61.7c8.1,0,14.1-1.9,18.1-5.7 c3.9-3.8,5.9-9,5.9-15.6c0-6.3-2-11.3-5.9-15.1c-4-3.8-10-5.7-18.1-5.7h-61.7V329.6z"/><path fill="currentColor" d="M1090.1,244.5h64.1v192.4h-64.1V244.5z"/></g><path fill="currentColor" d="M1255,437.1c59.1-10.5,150.2-56,151.7-104.8c2.1-69.4-158.2-148.8-533.3-172.2 c-281.2-17.5-546.3,23.8-769.2,38.2C503.8,97.2,727.3,37.3,905.5,62c112.2,15.6,295.7,128.9,360.4,240.9 C1285.2,336.5,1291.4,384.7,1255,437.1z"/></g></svg>)SVG";
+
+std::string toLower(std::string s)
+{
+  for (char &c : s)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return s;
+}
+
+std::string categoryId(const std::string &category)
+{
+  std::string id = "cat-";
+  for (char c : category)
+    id += std::isalnum(static_cast<unsigned char>(c)) ? c : '-';
+  return id;
+}
+
+std::string readFileBytes(const std::filesystem::path &path, bool &ok)
+{
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    ok = false;
+    return {};
+  }
+  std::ostringstream buffer;
+  buffer << in.rdbuf();
+  ok = true;
+  return buffer.str();
+}
+
+// The src for a channel image, or empty when there is nothing to show: an
+// absent path, a missing file, or an image excluded from an embedded file
+// because its Case is not in the initial (embedded) selection. srcPrefix
+// rebases the sidecar's workdir-relative path onto the HTML document's
+// directory for non-embedded references.
+std::string imageSrc(const std::filesystem::path &root,
+    const std::string &relPath,
+    bool embed,
+    bool selected,
+    const std::string &srcPrefix)
+{
+  if (relPath.empty())
+    return {};
+  const auto abs = root / relPath;
+  if (embed) {
+    if (!selected)
+      return {};
+    bool ok = false;
+    const std::string bytes = readFileBytes(abs, ok);
+    if (!ok)
+      return {};
+    return "data:image/png;base64," + base64Encode(bytes);
+  }
+  std::error_code ec;
+  if (!std::filesystem::is_regular_file(abs, ec))
+    return {};
+  return htmlEscape(srcPrefix + relPath);
+}
+
+// The prefix that rebases a workdir-relative image path onto the HTML
+// document's directory, ending in '/' when non-empty. Falls back to the
+// absolute workdir when no relative path exists (e.g. across drives).
+std::string imageSrcPrefix(
+    const std::filesystem::path &workdir, const std::filesystem::path &htmlPath)
+{
+  if (htmlPath.empty())
+    return {};
+  std::error_code ec;
+  const auto htmlDir =
+      std::filesystem::weakly_canonical(std::filesystem::absolute(htmlPath), ec)
+          .parent_path();
+  const auto absWorkdir =
+      std::filesystem::weakly_canonical(std::filesystem::absolute(workdir), ec);
+  auto base = std::filesystem::relative(absWorkdir, htmlDir, ec);
+  if (ec || base.empty())
+    base = absWorkdir;
+  if (base == ".")
+    return {};
+  return base.generic_string() + "/";
+}
+
+// A finite score, formatted to a fixed precision, or an em dash for non-finite
+// (e.g. PSNR of identical images, which the sidecar stores as null).
+std::string fixed(double value, int precision)
+{
+  if (!std::isfinite(value))
+    return "—";
+  std::ostringstream os;
+  os.setf(std::ios::fixed);
+  os.precision(precision);
+  os << value;
+  return os.str();
+}
+
+// A metric passes strictly above its threshold; a non-finite (perfect) score
+// always passes. With no threshold, defer to the channel verdict.
+bool metricPasses(
+    double value, const ChannelResult &ch, const std::string &name)
+{
+  auto thr = ch.thresholds.find(name);
+  if (thr == ch.thresholds.end())
+    return ch.passed;
+  return !std::isfinite(value) || value > thr->second;
+}
+
+std::string axisText(const CaseResult &r)
+{
+  std::string out;
+  for (const auto &[name, value] : r.axisValues) {
+    if (!out.empty())
+      out += ", ";
+    out += name + "=" + value;
+  }
+  return out.empty() ? "—" : out;
+}
+
+const char *verdictClass(Verdict v)
+{
+  switch (v) {
+  case Verdict::Passed:
+    return "passed";
+  case Verdict::Failed:
+    return "failed";
+  case Verdict::Skipped:
+    return "skipped";
+  }
+  return "skipped";
+}
+
+const char *verdictLabel(Verdict v)
+{
+  switch (v) {
+  case Verdict::Passed:
+    return "Passed";
+  case Verdict::Failed:
+    return "Failed";
+  case Verdict::Skipped:
+    return "Skipped";
+  }
+  return "Skipped";
+}
+
+// The one-line metric summary shown on a collapsed row (first channel).
+std::string primaryMetric(const CaseResult &r)
+{
+  if (r.verdict == Verdict::Skipped || r.channels.empty())
+    return "skipped";
+  const ChannelResult &ch = r.channels.front();
+  std::string out;
+  auto ssim = ch.metrics.find("ssim");
+  auto psnr = ch.metrics.find("psnr");
+  if (ssim != ch.metrics.end())
+    out += "SSIM " + fixed(ssim->second, 3);
+  if (psnr != ch.metrics.end())
+    out += (out.empty() ? "" : " · ") + std::string("PSNR ")
+        + fixed(psnr->second, 1) + " dB";
+  return out.empty() ? "—" : out;
+}
+
+void appendComparePane(std::ostringstream &os,
+    const std::filesystem::path &root,
+    const ChannelResult &ch,
+    bool embed,
+    bool selected,
+    const std::string &srcPrefix)
+{
+  const std::string result =
+      imageSrc(root, ch.resultImage, embed, selected, srcPrefix);
+  const std::string truth =
+      imageSrc(root, ch.groundTruthImage, embed, selected, srcPrefix);
+  // Always embed the diff (the only image the mask canvas reads back), so its
+  // interactive threshold and "over actual" work even in a non-embedded report
+  // where a referenced file:// diff would taint the canvas. Bounded by the same
+  // `selected` rule as embedding, so a failures-only report embeds only failed
+  // cases' diffs. The larger result/reference images still follow `embed`.
+  const std::string diff =
+      imageSrc(root, ch.diffImage, /*embed=*/true, selected, srcPrefix);
+
+  os << "<div class=\"compare\">";
+
+  // A/B compare pane: click or the toggle flips reference vs. actual.
+  os << "<div class=\"compare-pane\"><div class=\"pane-head\"><span "
+        "class=\"lbl\">A / B compare</span>";
+  if (!result.empty() && !truth.empty())
+    os << "<span class=\"segmented\"><button type=\"button\" class=\"abseg "
+          "active\" data-ab=\"result\">Actual</button><button type=\"button\" "
+          "class=\"abseg\" data-ab=\"reference\">Reference</button></span>";
+  os << "</div>";
+  if (!result.empty() || !truth.empty()) {
+    os << "<div class=\"stage\" data-ab=\"result\">";
+    if (!result.empty())
+      os << "<img class=\"layer\" data-role=\"result\" loading=\"lazy\" alt=\"actual\" "
+            "src=\""
+         << result << "\">";
+    if (!truth.empty())
+      os << "<img class=\"layer\" data-role=\"groundTruth\" loading=\"lazy\" "
+            "alt=\"reference\" src=\""
+         << truth << "\">";
+    os << "<span class=\"tag actual\">ACTUAL — THIS RUN</span>"
+          "<span class=\"tag reference\">REFERENCE — GROUND TRUTH</span></div>"
+          "<div class=\"cap-line\">Click image or toggle to flip between "
+          "reference and this run</div>";
+  } else {
+    os << "<div class=\"no-images\">images not embedded (regenerate with "
+          "--embed --all)</div>";
+  }
+  os << "</div>"; // compare-pane
+
+  // Difference-mask pane: an interactive canvas that thresholds the diff image
+  // live (slider), paints exceeded pixels red, and can composite them over a
+  // dimmed actual render. The canvas reads diff pixels; the diff is always
+  // embedded (above) so this works regardless of --embed. The tainted-canvas
+  // fallback below still guards cases whose diff is not embedded (an
+  // initially-hidden passing case in a failures-only report).
+  os << "<div class=\"mask-pane\"><div class=\"pane-head\"><span "
+        "class=\"lbl\">Difference mask</span>";
+  if (!diff.empty())
+    os << "<label class=\"overtoggle\"><input type=\"checkbox\" "
+          "class=\"over-actual\"> over actual</label>";
+  os << "</div>";
+  if (!diff.empty()) {
+    os << "<div class=\"maskbox\"><canvas class=\"maskcanvas\" data-diff=\""
+       << diff << "\"></canvas></div>";
+    os << "<div class=\"threshrow\"><span class=\"tlabel\">threshold</span>"
+          "<input type=\"range\" class=\"threshslider\" min=\"0\" max=\"255\" "
+          "value=\"16\" aria-label=\"difference threshold\"><span class=\"tval "
+          "kmono\">16</span></div>";
+    os << "<div class=\"cap-line\">Pixels whose per-channel difference exceeds "
+          "the threshold are painted red; “over actual” dims the render "
+          "beneath them</div>";
+  } else {
+    os << "<div class=\"no-images\">no difference image</div>";
+  }
+  os << "</div>"; // mask-pane
+  os << "</div>"; // compare
+}
+
+void appendMetricsTable(std::ostringstream &os, const CaseResult &r)
+{
+  os << "<div><div class=\"lbl\">Channel metrics</div><div class=\"tbl\">"
+        "<div class=\"thead\"><div>Channel</div><div>SSIM</div><div>PSNR</div>"
+        "<div class=\"res\">Result</div></div>";
+  for (const auto &ch : r.channels) {
+    auto ssim = ch.metrics.find("ssim");
+    auto psnr = ch.metrics.find("psnr");
+    const bool ok = ch.passed;
+    os << "<div class=\"trow\"><div class=\"kmono dark-fg\">"
+       << htmlEscape(channelName(ch.channel)) << "</div>";
+    // SSIM
+    os << "<div class=\"kmono "
+       << (ssim != ch.metrics.end() && metricPasses(ssim->second, ch, "ssim")
+                  ? "dark-fg"
+                  : "fail-fg")
+       << "\">";
+    if (ssim != ch.metrics.end()) {
+      os << fixed(ssim->second, 3);
+      auto t = ch.thresholds.find("ssim");
+      if (t != ch.thresholds.end())
+        os << " <span class=\"skip-fg\">/ " << fixed(t->second, 2) << "</span>";
+    } else
+      os << "—";
+    os << "</div>";
+    // PSNR
+    os << "<div class=\"kmono "
+       << (psnr != ch.metrics.end() && metricPasses(psnr->second, ch, "psnr")
+                  ? "dark-fg"
+                  : "fail-fg")
+       << "\">";
+    if (psnr != ch.metrics.end()) {
+      os << fixed(psnr->second, 1) << " dB";
+      auto t = ch.thresholds.find("psnr");
+      if (t != ch.thresholds.end())
+        os << " <span class=\"skip-fg\">/ " << fixed(t->second, 0) << "</span>";
+    } else
+      os << "—";
+    os << "</div>";
+    os << "<div class=\"res " << (ok ? "pass-fg" : "fail-fg") << "\">"
+       << (ok ? "PASS" : "FAIL") << "</div></div>";
+  }
+  os << "</div></div>";
+}
+
+void appendConfigTable(std::ostringstream &os, const CaseResult &r)
+{
+  const std::string device =
+      r.device.library + " · " + r.device.device + " / " + r.device.renderer;
+  const std::string dur = r.verdict == Verdict::Skipped
+      ? std::string("—")
+      : fixed(r.durationMs, 2) + " ms";
+  os << "<div><div class=\"lbl\">Configuration</div><div class=\"cfg\">";
+  auto rowKV =
+      [&](const char *k, const std::string &v, const char *cls = "vv") {
+        os << "<div class=\"r\"><span class=\"kk\">" << k
+           << "</span><span class=\"" << cls << "\">"
+           << htmlEscape(v.empty() ? "—" : v) << "</span></div>";
+      };
+  rowKV("Device", device);
+  rowKV("Axes", axisText(r));
+  rowKV("Detail", r.detail);
+  rowKV("Duration", dur);
+  os << "<div class=\"r\"><span class=\"kk\">Ground truth</span><span "
+        "class=\"vv\" style=\"color:var(--link);\">"
+     << htmlEscape(r.groundTruthKey.empty() ? "—" : r.groundTruthKey)
+     << "</span></div>";
+  os << "</div></div>";
+}
+
+bool hasAnyImage(const CaseResult &r)
+{
+  for (const auto &ch : r.channels)
+    if (!ch.resultImage.empty() || !ch.groundTruthImage.empty()
+        || !ch.diffImage.empty() || !ch.thresholdImage.empty())
+      return true;
+  return false;
+}
+
+void appendTestRow(std::ostringstream &os,
+    const std::filesystem::path &root,
+    const std::string &key,
+    const CaseResult &r,
+    bool embed,
+    bool includeAll,
+    const std::string &srcPrefix)
+{
+  // Embedded reports carry images only for the initially-shown Cases (failures
+  // unless --all); passing Cases still appear, with their metadata.
+  const bool selected = includeAll || r.verdict == Verdict::Failed;
+  const char *vc = verdictClass(r.verdict);
+  const std::string name = r.test + " / " + r.caseId;
+  const std::string searchText =
+      toLower(key + " " + r.description + " " + axisText(r));
+  const char *metricFg = r.verdict == Verdict::Skipped
+      ? "skip-fg"
+      : (r.verdict == Verdict::Failed ? "fail-fg" : "pass-fg");
+  const std::string dur = r.verdict == Verdict::Skipped
+      ? std::string("—")
+      : fixed(r.durationMs, 2) + " ms";
+
+  os << "<div class=\"test\" data-verdict=\"" << vc << "\" data-category=\""
+     << htmlEscape(r.category) << "\" data-key=\"" << htmlEscape(key)
+     << "\" data-search=\"" << htmlEscape(searchText) << "\">";
+
+  // Collapsed row.
+  os << "<div class=\"row\"><div><span class=\"badge " << vc << "\">"
+     << verdictLabel(r.verdict) << "</span></div>";
+  os << "<div style=\"min-width:0;\"><div class=\"name\">" << htmlEscape(name)
+     << "</div><div class=\"desc\">" << htmlEscape(r.description)
+     << "</div></div>";
+  os << "<div class=\"metric " << metricFg << "\">"
+     << htmlEscape(primaryMetric(r)) << "</div>";
+  os << "<div class=\"dur\">" << htmlEscape(dur) << "</div>";
+  os << "<div class=\"chev\">›</div></div>";
+
+  // Expanded panel.
+  os << "<div class=\"panel\">";
+  const bool skipped = r.verdict == Verdict::Skipped || r.channels.empty();
+  if (skipped) {
+    const std::string reason = !r.skipReason.empty() ? r.skipReason : r.detail;
+    os << "<div class=\"compare\"><div class=\"skipnote\"><span "
+          "class=\"dot\"></span><div><div class=\"h\">No images captured</div>"
+          "<div class=\"r\">"
+       << htmlEscape(reason.empty() ? "This case produced no rendered channels."
+                                    : reason)
+       << "</div></div></div></div>";
+  } else if (!hasAnyImage(r)) {
+    os << "<div class=\"compare\"><div class=\"no-images\">no images</div></div>";
+  } else {
+    // One comparison block per channel.
+    for (const auto &ch : r.channels)
+      appendComparePane(os, root, ch, embed, selected, srcPrefix);
+  }
+  if (!r.channels.empty()) {
+    os << "<div class=\"meta\">";
+    appendMetricsTable(os, r);
+    appendConfigTable(os, r);
+    os << "</div>";
+  }
+  os << "</div>"; // panel
+  os << "</div>"; // test
+}
+
+std::string ringStyle(int passed, int failed, int total)
+{
+  const double denom = total > 0 ? total : 1;
+  const double passDeg = passed / denom * 360.0;
+  const double failEnd = (passed + failed) / denom * 360.0;
+  std::ostringstream os;
+  os.setf(std::ios::fixed);
+  os.precision(1);
+  os << "background:conic-gradient(var(--accent) 0 " << passDeg << "deg,"
+     << "var(--fail) 0 " << failEnd << "deg,#d3d9de 0);";
+  return os.str();
+}
+
+} // namespace
+
+std::string htmlEscape(const std::string &text)
+{
+  std::string out;
+  out.reserve(text.size());
+  for (char c : text) {
+    switch (c) {
+    case '&':
+      out += "&amp;";
+      break;
+    case '<':
+      out += "&lt;";
+      break;
+    case '>':
+      out += "&gt;";
+      break;
+    case '"':
+      out += "&quot;";
+      break;
+    case '\'':
+      out += "&#39;";
+      break;
+    default:
+      out += c;
+    }
+  }
+  return out;
+}
+
+std::string base64Encode(const std::string &bytes)
+{
+  static constexpr char kTable[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  out.reserve((bytes.size() + 2) / 3 * 4);
+  size_t i = 0;
+  const size_t n = bytes.size();
+  while (i + 3 <= n) {
+    const uint32_t v = (uint8_t(bytes[i]) << 16) | (uint8_t(bytes[i + 1]) << 8)
+        | uint8_t(bytes[i + 2]);
+    out += kTable[(v >> 18) & 0x3f];
+    out += kTable[(v >> 12) & 0x3f];
+    out += kTable[(v >> 6) & 0x3f];
+    out += kTable[v & 0x3f];
+    i += 3;
+  }
+  if (i + 1 == n) {
+    const uint32_t v = uint8_t(bytes[i]) << 16;
+    out += kTable[(v >> 18) & 0x3f];
+    out += kTable[(v >> 12) & 0x3f];
+    out += "==";
+  } else if (i + 2 == n) {
+    const uint32_t v = (uint8_t(bytes[i]) << 16) | (uint8_t(bytes[i + 1]) << 8);
+    out += kTable[(v >> 18) & 0x3f];
+    out += kTable[(v >> 12) & 0x3f];
+    out += kTable[(v >> 6) & 0x3f];
+    out += "=";
+  }
+  return out;
+}
+
+std::string generateHtml(const std::filesystem::path &workdir,
+    const std::map<std::string, CaseResult> &results,
+    const HtmlOptions &opts)
+{
+  const Summary s = summarize(results);
+  const std::string srcPrefix =
+      opts.embed ? std::string() : imageSrcPrefix(workdir, opts.htmlPath);
+  const int executed = s.passed + s.failed;
+  const int passRate = executed > 0
+      ? static_cast<int>(std::lround(100.0 * s.passed / executed))
+      : 0;
+  double wallMs = 0.0;
+  for (const auto &[key, r] : results)
+    wallMs += r.durationMs;
+
+  std::ostringstream warnings;
+  const std::string label =
+      deviceLabel(results, workdir.filename().string(), warnings);
+  const std::string runName = workdir.filename().string();
+  const std::string title = "ANARI CTS — " + runName;
+
+  std::ostringstream os;
+  os << "<!DOCTYPE html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width, "
+        "initial-scale=1\"><title>"
+     << htmlEscape(title) << "</title><style>" << kStyle
+     << "</style></head><body><div class=\"wrap\">";
+
+  // Header.
+  os << "<header><div class=\"brand\">" << kAnariLogo
+     << "<div><div class=\"title\">Conformance Test Suite</div>"
+        "<div class=\"subtitle\">Image comparison — "
+        "device under test: <span class=\"kmono\">"
+     << htmlEscape(label) << "</span></div></div></div>";
+  os << "<div class=\"runbox\">Run<br><span class=\"kmono\" "
+        "style=\"font-size:13px;color:var(--dark);text-transform:none;"
+        "letter-spacing:0;\">"
+     << htmlEscape(runName) << "</span></div></header>";
+
+  // Summary: pass-rate ring + stat cards.
+  os << "<section class=\"summary\"><div class=\"ring-card\"><div class=\"ring\" "
+        "style=\""
+     << ringStyle(s.passed, s.failed, s.total) << "\"><div class=\"hole\">"
+     << "<div class=\"pct\">" << passRate
+     << "<span>%</span></div>"
+        "<div class=\"cap\">pass rate</div></div></div><div class=\"legend\">"
+        "<div class=\"row\"><span class=\"dot\" style=\"background:var(--pass);\">"
+        "</span>Passed<span class=\"n kmono\">"
+     << s.passed
+     << "</span></div><div class=\"row\"><span class=\"dot\" "
+        "style=\"background:var(--fail);\"></span>Failed<span class=\"n kmono\">"
+     << s.failed
+     << "</span></div><div class=\"row\"><span class=\"dot\" "
+        "style=\"background:var(--skip);\"></span>Skipped<span class=\"n kmono\">"
+     << s.skipped << "</span></div></div></div>";
+
+  os << "<div class=\"stats\">";
+  os << "<div class=\"stat\"><div class=\"k\">Total cases</div><div class=\"v "
+        "kmono\">"
+     << s.total << "</div><div class=\"sub\">" << executed
+     << " executed</div></div>";
+  os << "<div class=\"stat\"><div class=\"k\">Categories</div><div class=\"v "
+        "kmono\">"
+     << s.categories.size()
+     << "</div><div class=\"sub\">domains covered</div></div>";
+  os << "<div class=\"stat\"><div class=\"k\">Device under test</div><div "
+        "class=\"v sm kmono\">"
+     << htmlEscape(label) << "</div></div>";
+  os << "<div class=\"stat\"><div class=\"k\">Wall time</div><div class=\"v "
+        "kmono\">"
+     << fixed(wallMs, 0)
+     << " ms</div><div class=\"sub\">SSIM ≥ 0.70 · PSNR ≥ "
+        "20</div></div>";
+  os << "</div></section>";
+
+  // Toolbar: search + status filter + count.
+  os << "<section class=\"toolbar\"><div class=\"search\"><svg width=\"16\" "
+        "height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\"><circle cx=\"11\" "
+        "cy=\"11\" r=\"7\" stroke=\"currentColor\" stroke-width=\"2\"/><line "
+        "x1=\"16.5\" y1=\"16.5\" x2=\"21\" y2=\"21\" stroke=\"currentColor\" "
+        "stroke-width=\"2\" stroke-linecap=\"round\"/></svg><input "
+        "type=\"search\" id=\"search\" placeholder=\"Search id / "
+        "description…\"></div>";
+  os << "<div class=\"segctl\">"
+        "<button type=\"button\" class=\"statusseg active\" data-status=\"all\">All "
+     << s.total
+     << "</button><button type=\"button\" class=\"statusseg\" "
+        "data-status=\"passed\">Passed "
+     << s.passed
+     << "</button><button type=\"button\" class=\"statusseg\" "
+        "data-status=\"failed\">Failed "
+     << s.failed
+     << "</button><button type=\"button\" class=\"statusseg\" "
+        "data-status=\"skipped\">Skipped "
+     << s.skipped << "</button></div>";
+  // Sort control. "Failed first" defaults on when the run has any failures, so
+  // the most actionable Cases lead on open.
+  const bool failedFirstDefault = s.failed > 0;
+  os << "<div class=\"segctl\"><button type=\"button\" class=\"sortseg"
+     << (failedFirstDefault ? " active" : "")
+     << "\" data-sort=\"failed\">Failed first</button>"
+        "<button type=\"button\" class=\"sortseg"
+     << (failedFirstDefault ? "" : " active")
+     << "\" data-sort=\"category\">By category</button></div>";
+  os << "<div class=\"showing\">Showing <span class=\"kmono\" "
+        "id=\"shown\">"
+     << s.total << "</span> of <span class=\"kmono\">" << s.total
+     << "</span></div></section>";
+
+  // Category groups. Rows and their group headers are flat siblings in #list so
+  // the client can either keep the grouping (headers shown) or re-sort rows
+  // "failed first" across the whole list (headers hidden).
+  os << "<section><div id=\"list\">";
+  // Synthetic header for the "failed first" section; hidden until that sort is
+  // active (and when the run has no failures). Labeled "All failed" when every
+  // Case failed.
+  const bool allFailed = s.failed > 0 && s.failed == s.total;
+  os << "<div class=\"group-head fail-head\" id=\"failed-head\" hidden><span "
+        "class=\"name\">"
+     << (allFailed ? "All failed" : "Failed")
+     << "</span><span class=\"rule\"></span><span class=\"pfs\"><span "
+        "class=\"kmono fail-fg\" data-c=\"f\">"
+     << s.failed << "F</span></span></div>";
+  std::string currentCategory;
+  for (const auto &[key, r] : results) {
+    if (r.category != currentCategory) {
+      currentCategory = r.category;
+      const auto &c = s.categories.at(currentCategory);
+      os << "<div class=\"group-head\" id=\"" << categoryId(currentCategory)
+         << "\"><span class=\"name\">" << htmlEscape(currentCategory)
+         << "</span><span class=\"rule\"></span><span class=\"pfs\">"
+            "<span class=\"kmono pass-fg\" data-c=\"p\">"
+         << c.passed << "P</span><span class=\"kmono fail-fg\" data-c=\"f\">"
+         << c.failed << "F</span><span class=\"kmono skip-fg\" data-c=\"s\">"
+         << c.skipped << "S</span></span></div>";
+    }
+    appendTestRow(os, workdir, key, r, opts.embed, opts.includeAll, srcPrefix);
+  }
+  os << "</div>"; // #list
+
+  os << "<div class=\"empty\" id=\"noresults\" hidden><div class=\"h\">No cases "
+        "match your filters</div><div class=\"s\">Try a different search term "
+        "or status filter.</div></div>";
+  os << "</section>";
+
+  os << "</div><script>" << kScript << "</script></body></html>\n";
+  return os.str();
+}
+
+} // namespace cts
+} // namespace anari

--- a/src/anari_test_scenes/cts/HtmlReport.cpp
+++ b/src/anari_test_scenes/cts/HtmlReport.cpp
@@ -159,6 +159,11 @@ header {
   margin-bottom: 10px; }
 .pane-head .lbl { font-size: 11px; color: var(--muted2); text-transform: uppercase;
   letter-spacing: .07em; }
+.chan { margin-left: 7px; padding: 1px 6px; border-radius: 4px;
+  font-size: 9.5px; font-weight: 700; letter-spacing: .05em;
+  background: var(--border); color: var(--muted2); }
+.chan-color { background: rgba(72,122,144,.15); color: var(--accent); }
+.chan-depth { background: rgba(111,119,129,.18); color: var(--dark); }
 .stage { position: relative; border: 1px solid var(--border); border-radius: 9px;
   overflow: hidden; background: #000; cursor: pointer; aspect-ratio: 1 / 1; }
 .stage .layer { position: absolute; inset: 0; width: 100%; height: 100%;
@@ -544,6 +549,15 @@ const char *verdictClass(Verdict v)
   return "skipped";
 }
 
+// The channel name, upper-cased for the pane-head chip (e.g. "COLOR").
+std::string channelTag(Channel c)
+{
+  std::string s = channelName(c);
+  for (char &ch : s)
+    ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+  return s;
+}
+
 const char *verdictLabel(Verdict v)
 {
   switch (v) {
@@ -597,7 +611,9 @@ void appendComparePane(std::ostringstream &os,
 
   // A/B compare pane: click or the toggle flips reference vs. actual.
   os << "<div class=\"compare-pane\"><div class=\"pane-head\"><span "
-        "class=\"lbl\">A / B compare</span>";
+        "class=\"lbl\">A / B compare<span class=\"chan chan-"
+     << channelName(ch.channel) << "\">" << channelTag(ch.channel)
+     << "</span></span>";
   if (!result.empty() && !truth.empty())
     os << "<span class=\"segmented\"><button type=\"button\" class=\"abseg "
           "active\" data-ab=\"result\">Actual</button><button type=\"button\" "
@@ -630,7 +646,9 @@ void appendComparePane(std::ostringstream &os,
   // fallback below still guards cases whose diff is not embedded (an
   // initially-hidden passing case in a failures-only report).
   os << "<div class=\"mask-pane\"><div class=\"pane-head\"><span "
-        "class=\"lbl\">Difference mask</span>";
+        "class=\"lbl\">Difference mask<span class=\"chan chan-"
+     << channelName(ch.channel) << "\">" << channelTag(ch.channel)
+     << "</span></span>";
   if (!diff.empty())
     os << "<label class=\"overtoggle\"><input type=\"checkbox\" "
           "class=\"over-actual\"> over actual</label>";

--- a/src/anari_test_scenes/cts/HtmlReport.h
+++ b/src/anari_test_scenes/cts/HtmlReport.h
@@ -1,0 +1,48 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Sidecar.h"
+// std
+#include <filesystem>
+#include <map>
+#include <string>
+
+// The HTML report: a single self-contained, interactive document rendered from
+// a run's results tree. Every Case's metadata is always present so the client
+// can filter by verdict and search without a server; which images travel with
+// the file depends on `embed` and the initial filter (a passing Case is not
+// embedded in a failures-only report). See Report.h for the shared aggregation.
+namespace anari {
+namespace cts {
+
+struct HtmlOptions
+{
+  // The initial verdict filter shows failures only unless includeAll is set;
+  // the reader can always toggle passed/skipped back on client-side.
+  bool includeAll{false};
+  // Inline images as base64 data URIs (a portable single file) instead of
+  // referencing the PNGs in the workdir. Only the initially-shown Cases are
+  // embedded, so the file stays bounded; `--embed --all` embeds everything.
+  bool embed{false};
+  // Where the document will be written. Browsers resolve non-embedded image
+  // references against this location, so they are emitted relative to it.
+  // Empty keeps them workdir-relative (only correct for a document placed in
+  // the workdir root).
+  std::filesystem::path htmlPath;
+};
+
+// Render the full HTML document for a run's results tree.
+std::string generateHtml(const std::filesystem::path &workdir,
+    const std::map<std::string, CaseResult> &results,
+    const HtmlOptions &opts);
+
+// Escape text for HTML text and double-quoted attribute content.
+std::string htmlEscape(const std::string &text);
+
+// Standard base64 of arbitrary bytes (no line wrapping).
+std::string base64Encode(const std::string &bytes);
+
+} // namespace cts
+} // namespace anari

--- a/src/anari_test_scenes/cts/RendererParams.cpp
+++ b/src/anari_test_scenes/cts/RendererParams.cpp
@@ -1,0 +1,205 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "RendererParams.h"
+// std
+#include <cstdint>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace anari {
+namespace cts {
+
+namespace {
+
+std::string trim(const std::string &s)
+{
+  const auto first = s.find_first_not_of(" \t");
+  if (first == std::string::npos)
+    return "";
+  const auto last = s.find_last_not_of(" \t");
+  return s.substr(first, last - first + 1);
+}
+
+// Parse the whole string as a float; false on trailing garbage or non-finite.
+bool parseFloat(const std::string &s, float &out)
+{
+  const std::string t = trim(s);
+  if (t.empty())
+    return false;
+  try {
+    size_t pos = 0;
+    out = std::stof(t, &pos);
+    return pos == t.size();
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+// Parse the whole string as a base-10 integer; false on trailing garbage.
+bool parseInt(const std::string &s, long &out)
+{
+  const std::string t = trim(s);
+  if (t.empty())
+    return false;
+  try {
+    size_t pos = 0;
+    out = std::stol(t, &pos, 10);
+    return pos == t.size();
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+std::vector<std::string> splitCommas(const std::string &s)
+{
+  std::vector<std::string> parts;
+  std::stringstream ss(s);
+  std::string part;
+  while (std::getline(ss, part, ','))
+    parts.push_back(trim(part));
+  return parts;
+}
+
+template <typename T>
+void appendBytes(std::vector<std::byte> &out, T v)
+{
+  const auto *p = reinterpret_cast<const std::byte *>(&v);
+  out.insert(out.end(), p, p + sizeof(T));
+}
+
+ANARIDataType floatVectorType(size_t components)
+{
+  switch (components) {
+  case 2:
+    return ANARI_FLOAT32_VEC2;
+  case 3:
+    return ANARI_FLOAT32_VEC3;
+  case 4:
+    return ANARI_FLOAT32_VEC4;
+  default:
+    return ANARI_UNKNOWN;
+  }
+}
+
+std::optional<ParsedParam> parseFloatVector(
+    const std::string &text, ANARIDataType type, size_t components)
+{
+  const auto parts = splitCommas(text);
+  if (parts.size() != components)
+    return {};
+  ParsedParam out;
+  out.type = type;
+  for (const auto &p : parts) {
+    float v = 0.f;
+    if (!parseFloat(p, v))
+      return {};
+    appendBytes(out.bytes, v);
+  }
+  return out;
+}
+
+} // namespace
+
+std::optional<RendererParam> parseRendererParam(const std::string &arg)
+{
+  const auto eq = arg.find('=');
+  if (eq == std::string::npos)
+    return {};
+  RendererParam p;
+  p.name = trim(arg.substr(0, eq));
+  p.value = arg.substr(eq + 1);
+  if (p.name.empty())
+    return {};
+  return p;
+}
+
+ANARIDataType inferParamType(const std::string &text)
+{
+  const std::string t = trim(text);
+  if (t == "true" || t == "false")
+    return ANARI_BOOL;
+
+  if (t.find(',') != std::string::npos) {
+    const auto parts = splitCommas(t);
+    if (floatVectorType(parts.size()) != ANARI_UNKNOWN) {
+      bool allFloats = true;
+      for (const auto &p : parts) {
+        float v = 0.f;
+        allFloats = allFloats && parseFloat(p, v);
+      }
+      if (allFloats)
+        return floatVectorType(parts.size());
+    }
+    return ANARI_STRING;
+  }
+
+  long i = 0;
+  if (parseInt(t, i))
+    return ANARI_INT32;
+  float f = 0.f;
+  if (parseFloat(t, f))
+    return ANARI_FLOAT32;
+  return ANARI_STRING;
+}
+
+std::optional<ParsedParam> parseParamValue(
+    ANARIDataType type, const std::string &text)
+{
+  const ANARIDataType resolved =
+      type == ANARI_UNKNOWN ? inferParamType(text) : type;
+
+  ParsedParam out;
+  out.type = resolved;
+  switch (resolved) {
+  case ANARI_BOOL: {
+    const std::string t = trim(text);
+    if (t == "true" || t == "1")
+      appendBytes<int8_t>(out.bytes, 1);
+    else if (t == "false" || t == "0")
+      appendBytes<int8_t>(out.bytes, 0);
+    else
+      return {};
+    return out;
+  }
+  case ANARI_INT32: {
+    long v = 0;
+    if (!parseInt(text, v))
+      return {};
+    appendBytes<int32_t>(out.bytes, static_cast<int32_t>(v));
+    return out;
+  }
+  case ANARI_UINT32: {
+    long v = 0;
+    if (!parseInt(text, v) || v < 0)
+      return {};
+    appendBytes<uint32_t>(out.bytes, static_cast<uint32_t>(v));
+    return out;
+  }
+  case ANARI_FLOAT32: {
+    float v = 0.f;
+    if (!parseFloat(text, v))
+      return {};
+    appendBytes<float>(out.bytes, v);
+    return out;
+  }
+  case ANARI_FLOAT32_VEC2:
+    return parseFloatVector(text, resolved, 2);
+  case ANARI_FLOAT32_VEC3:
+    return parseFloatVector(text, resolved, 3);
+  case ANARI_FLOAT32_VEC4:
+    return parseFloatVector(text, resolved, 4);
+  case ANARI_STRING: {
+    out.bytes.assign(reinterpret_cast<const std::byte *>(text.c_str()),
+        reinterpret_cast<const std::byte *>(text.c_str()) + text.size() + 1);
+    return out;
+  }
+  default:
+    return {};
+  }
+}
+
+} // namespace cts
+} // namespace anari

--- a/src/anari_test_scenes/cts/RendererParams.h
+++ b/src/anari_test_scenes/cts/RendererParams.h
@@ -1,0 +1,65 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Device-agnostic renderer parameter overrides. The CLI collects NAME=VALUE
+// pairs (e.g. ambientSample=4) and the runner applies them to every Case's
+// renderer. Typing is resolved against the device itself: the runner asks the
+// renderer subtype for the parameter's declared ANARIDataType and parses the
+// text into it, so no device-specific knowledge lives here. When the device
+// does not report the parameter, the type is inferred from the text.
+//
+// Parsing is pure (no device) so it is unit-testable; the runner owns the
+// device introspection and the anariSetParameter call.
+
+// anari
+#include "anari/anari.h"
+// std
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace anari {
+namespace cts {
+
+// A renderer parameter override supplied on the command line as NAME=VALUE.
+struct RendererParam
+{
+  std::string name;
+  std::string value; // raw, unparsed text
+};
+
+// Parse a "name=value" argument, splitting on the first '='. Returns nullopt
+// when '=' is absent or the name is empty. The value may be empty and may
+// itself contain '='.
+std::optional<RendererParam> parseRendererParam(const std::string &arg);
+
+// A value parsed into the byte layout anariSetParameter expects. `type` is
+// ANARI_UNKNOWN only when parsing failed.
+struct ParsedParam
+{
+  ANARIDataType type{ANARI_UNKNOWN};
+  // Scalar/vector payload in native ANARI layout, or a NUL-terminated string.
+  std::vector<std::byte> bytes;
+
+  const void *data() const
+  {
+    return bytes.data();
+  }
+};
+
+// Infer an ANARI type from `text`: bool (true/false), int32, float32,
+// float32_vecN (N in 2..4, comma-separated), else string.
+ANARIDataType inferParamType(const std::string &text);
+
+// Parse `text` as `type`. When `type` is ANARI_UNKNOWN the type is inferred
+// first. Returns nullopt when the text does not parse as the resolved type or
+// the type is unsupported. Supported: BOOL, INT32, UINT32, FLOAT32,
+// FLOAT32_VEC2/3/4, STRING.
+std::optional<ParsedParam> parseParamValue(
+    ANARIDataType type, const std::string &text);
+
+} // namespace cts
+} // namespace anari

--- a/src/anari_test_scenes/cts/Report.cpp
+++ b/src/anari_test_scenes/cts/Report.cpp
@@ -1,0 +1,206 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Report.h"
+// std
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <tuple>
+
+namespace anari {
+namespace cts {
+
+const std::vector<std::string> kReportMetrics = {"ssim", "psnr"};
+
+namespace {
+
+std::string caseKey(const CaseResult &r)
+{
+  return r.category + "/" + r.test + "/" + r.caseId;
+}
+
+// A finite score formatted like the Python reader, or "null" for non-finite.
+std::string metricText(double value)
+{
+  if (!std::isfinite(value))
+    return "null";
+  std::ostringstream os;
+  os << value;
+  return os.str();
+}
+
+// The per-channel "metric=score" list a summary prints for one Case.
+std::string channelScores(const CaseResult &r)
+{
+  std::ostringstream os;
+  bool firstChannel = true;
+  for (const auto &ch : r.channels) {
+    if (!firstChannel)
+      os << "; ";
+    firstChannel = false;
+    os << channelName(ch.channel) << "(";
+    bool firstMetric = true;
+    for (const auto &m : kReportMetrics) {
+      auto it = ch.metrics.find(m);
+      if (it == ch.metrics.end())
+        continue;
+      if (!firstMetric)
+        os << ", ";
+      firstMetric = false;
+      os << m << "=" << metricText(it->second);
+    }
+    os << ")";
+  }
+  return os.str();
+}
+
+} // namespace
+
+std::map<std::string, CaseResult> loadResults(
+    const std::filesystem::path &workdir, std::ostream &warnings)
+{
+  std::map<std::string, CaseResult> out;
+  const auto results = workdir / "results";
+  std::error_code ec;
+  if (!std::filesystem::is_directory(results, ec))
+    return out;
+
+  // Deterministic order so the "first read wins" duplicate rule is stable.
+  std::vector<std::filesystem::path> paths;
+  for (auto &entry : std::filesystem::recursive_directory_iterator(results, ec))
+    if (entry.path().extension() == ".json")
+      paths.push_back(entry.path());
+  std::sort(paths.begin(), paths.end());
+
+  for (const auto &path : paths) {
+    CaseResult r;
+    bool schemaMismatch = false;
+    if (!readSidecar(path, r, &schemaMismatch))
+      continue; // not a sidecar
+    if (schemaMismatch)
+      warnings << "warning: " << path
+               << " has an unexpected schemaVersion (expected "
+               << kSidecarSchemaVersion << "); reading best-effort\n";
+    const auto key = caseKey(r);
+    if (out.count(key)) {
+      warnings << "warning: duplicate logical Case key " << key << " in "
+               << path << "; keeping the first\n";
+      continue;
+    }
+    out.emplace(key, std::move(r));
+  }
+  return out;
+}
+
+Summary summarize(const std::map<std::string, CaseResult> &results)
+{
+  Summary s;
+  for (const auto &[key, r] : results) {
+    ++s.total;
+    auto &cat = s.categories[r.category];
+    switch (r.verdict) {
+    case Verdict::Passed:
+      ++s.passed;
+      ++cat.passed;
+      break;
+    case Verdict::Failed:
+      ++s.failed;
+      ++cat.failed;
+      s.failures.push_back(key);
+      break;
+    case Verdict::Skipped:
+      ++s.skipped;
+      ++cat.skipped;
+      break;
+    }
+  }
+  return s;
+}
+
+std::optional<DeviceSpec> runDevice(
+    const std::map<std::string, CaseResult> &results, std::ostream &warnings)
+{
+  std::map<std::tuple<std::string, std::string, std::string>, DeviceSpec>
+      devices;
+  for (const auto &[key, r] : results) {
+    if (r.device.library.empty())
+      continue;
+    devices.insert(
+        {{r.device.library, r.device.device, r.device.renderer}, r.device});
+  }
+  if (devices.size() > 1) {
+    warnings << "warning: mixed device identities in one run:";
+    for (const auto &[id, dev] : devices)
+      warnings << " " << dev.library << " (" << dev.device << "/"
+               << dev.renderer << ")";
+    warnings << "\n";
+    return std::nullopt;
+  }
+  if (devices.empty())
+    return std::nullopt;
+  return devices.begin()->second;
+}
+
+std::string deviceLabel(const std::map<std::string, CaseResult> &results,
+    const std::string &fallback,
+    std::ostream &warnings)
+{
+  const auto device = runDevice(results, warnings);
+  if (!device)
+    return fallback;
+  return device->library + " (" + device->device + "/" + device->renderer + ")";
+}
+
+std::vector<std::string> reportCaseKeys(
+    const std::map<std::string, CaseResult> &results, bool includeAll)
+{
+  if (!includeAll)
+    return summarize(results).failures;
+  std::vector<std::string> keys;
+  keys.reserve(results.size());
+  for (const auto &[key, r] : results)
+    keys.push_back(key);
+  return keys;
+}
+
+void writeTextSummary(std::ostream &out,
+    const std::string &workdir,
+    const std::map<std::string, CaseResult> &results,
+    bool includeAll)
+{
+  const Summary s = summarize(results);
+  out << "CTS report: " << workdir << "\n";
+  if (const auto device = runDevice(results, out))
+    out << "  device: " << device->library << " (" << device->device << "/"
+        << device->renderer << ")\n";
+  out << "  " << s.total << " cases: " << s.passed << " passed, " << s.failed
+      << " failed, " << s.skipped << " skipped\n";
+  out << "  by category:\n";
+  for (const auto &[cat, c] : s.categories)
+    out << "    " << std::left << std::setw(12) << cat << std::right
+        << std::setw(4) << c.passed << " passed  " << std::setw(4) << c.failed
+        << " failed  " << std::setw(4) << c.skipped << " skipped\n";
+
+  const auto keys = reportCaseKeys(results, includeAll);
+  if (keys.empty())
+    return;
+  out << "  " << (includeAll ? "all cases" : "failed cases") << ":\n";
+  for (const auto &key : keys) {
+    const auto &r = results.at(key);
+    const std::string scores = channelScores(r);
+    // Cases with no channel scores (behavioral, or a failed render) carry
+    // their reason in detail or skipReason instead.
+    const std::string reason = !r.detail.empty() ? r.detail : r.skipReason;
+    const std::string verdict =
+        includeAll ? std::string(" [") + verdictName(r.verdict) + "]" : "";
+    out << "    " << key << verdict << "  "
+        << (!scores.empty() ? scores : reason) << "\n";
+    if (!r.description.empty())
+      out << "      Description: " << r.description << "\n";
+  }
+}
+
+} // namespace cts
+} // namespace anari

--- a/src/anari_test_scenes/cts/Report.h
+++ b/src/anari_test_scenes/cts/Report.h
@@ -1,0 +1,77 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Sidecar.h"
+// std
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
+
+// The reporting layer: it reads a run's results tree (the per-Case sidecars,
+// ADR-0003) and aggregates it into a human summary. It never renders and never
+// opens a device; the sidecar tree is its only input. HTML rendering lives in
+// HtmlReport; PDF stays in the Python layer (the only output whose dependency
+// is not worth porting to C++).
+namespace anari {
+namespace cts {
+
+// The metrics surfaced in summaries, in display order. The single source is the
+// C++ runner; this list must track what it records.
+extern const std::vector<std::string> kReportMetrics;
+
+// Every sidecar under workdir/results, keyed by "category/test/case". Duplicate
+// logical keys and schema-version mismatches are diagnosed to `warnings` (the
+// first-read sidecar wins), mirroring the Python reader.
+std::map<std::string, CaseResult> loadResults(
+    const std::filesystem::path &workdir, std::ostream &warnings);
+
+// Per-category pass/fail/skip counts.
+struct CategoryCounts
+{
+  int passed{0};
+  int failed{0};
+  int skipped{0};
+};
+
+// A run's aggregate: overall counts, per-category counts, and failed case keys.
+struct Summary
+{
+  int total{0};
+  int passed{0};
+  int failed{0};
+  int skipped{0};
+  std::map<std::string, CategoryCounts> categories;
+  std::vector<std::string> failures;
+};
+
+Summary summarize(const std::map<std::string, CaseResult> &results);
+
+// The single device identity shared by a run's sidecars. Absent when the run is
+// empty or names more than one device (which is diagnosed to `warnings`), so a
+// mixed run is flagged rather than mislabeled by whichever sidecar read first.
+std::optional<DeviceSpec> runDevice(
+    const std::map<std::string, CaseResult> &results, std::ostream &warnings);
+
+// A human label for a run: its device identity, or `fallback` (the workdir
+// name) when the sidecars predate the device field.
+std::string deviceLabel(const std::map<std::string, CaseResult> &results,
+    const std::string &fallback,
+    std::ostream &warnings);
+
+// The case keys to itemize in a report: every case, or only failures.
+std::vector<std::string> reportCaseKeys(
+    const std::map<std::string, CaseResult> &results, bool includeAll);
+
+// Write the text summary (counts, per-category table, itemized cases).
+void writeTextSummary(std::ostream &out,
+    const std::string &workdir,
+    const std::map<std::string, CaseResult> &results,
+    bool includeAll);
+
+} // namespace cts
+} // namespace anari

--- a/src/anari_test_scenes/cts/Runner.cpp
+++ b/src/anari_test_scenes/cts/Runner.cpp
@@ -11,11 +11,14 @@
 #include "Value.h"
 #include "ViewBuilder.h"
 #include "WorldBuilder.h"
+// anari
+#include "anari/frontend/anari_device_introspection.hpp"
 // std
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -223,6 +226,42 @@ void Runner::resolveCapabilities(const std::set<std::string> &features)
       ? m_options.accumulationFrames
       : 1;
   m_denoiseEnabled = m_options.denoise;
+  resolveRendererParamTypes();
+}
+
+void Runner::resolveRendererParamTypes()
+{
+  m_rendererParamTypes.clear();
+  if (m_options.rendererParams.empty())
+    return;
+
+  introspection::QueryOptions qo;
+  qo.typeFilter = "RENDERER";
+  qo.includeParameters = true;
+  const auto info = introspection::queryDeviceInfo(m_device, qo);
+  for (const auto &obj : info.objects) {
+    if (obj.type != ANARI_RENDERER || obj.subtype != m_options.device.renderer)
+      continue;
+    for (const auto &p : obj.parameters)
+      m_rendererParamTypes[p.name] = p.type;
+  }
+}
+
+void Runner::applyRendererParams(anari::Renderer renderer)
+{
+  for (const auto &param : m_options.rendererParams) {
+    const auto it = m_rendererParamTypes.find(param.name);
+    const ANARIDataType declared =
+        it != m_rendererParamTypes.end() ? it->second : ANARI_UNKNOWN;
+    const auto parsed = parseParamValue(declared, param.value);
+    if (!parsed) {
+      std::cerr << "warning: could not parse renderer parameter '" << param.name
+                << "=" << param.value << "'; skipping\n";
+      continue;
+    }
+    anariSetParameter(
+        m_device, renderer, param.name.c_str(), parsed->type, parsed->data());
+  }
 }
 
 Runner::SceneObjects Runner::buildScene(const TestDef &test, const Case &c)
@@ -249,6 +288,7 @@ Runner::SceneObjects Runner::buildScene(const TestDef &test, const Case &c)
       configuredRenderer(
           m_device, m_options.device.renderer, m_options.ambientRadiance));
   if (scene.renderer) {
+    applyRendererParams(scene.renderer.get());
     if (test.rendererConfig)
       test.rendererConfig(ctx, scene.renderer.get());
     if (m_denoiseEnabled)

--- a/src/anari_test_scenes/cts/Runner.h
+++ b/src/anari_test_scenes/cts/Runner.h
@@ -7,12 +7,14 @@
 #include "ArtifactPublication.h"
 #include "Catalog.h"
 #include "Image.h"
+#include "RendererParams.h"
 #include "Sidecar.h"
 #include "TestDef.h"
 #include "Workdir.h"
 // anari
 #include "anari/anari_cpp.hpp"
 // std
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -32,6 +34,11 @@ struct RunOptions
   // Baseline renderer ambient light. A renderer Test may override this.
   float ambientRadiance{1.f};
   bool denoise{false};
+  // Device-agnostic renderer parameter overrides (CLI NAME=VALUE), applied to
+  // every Case's renderer over the baseline but before the Test's own renderer
+  // config, so a renderer Test that sets the same name still wins. Types
+  // resolve against the device's declared parameter metadata.
+  std::vector<RendererParam> rendererParams;
   DeviceSpec device;
 };
 
@@ -103,6 +110,17 @@ struct Runner
   // m_denoiseEnabled. Called once at the start of generate()/run().
   void resolveCapabilities(const std::set<std::string> &features);
 
+  // Query the selected renderer subtype's declared parameter types once, so
+  // CLI overrides parse into the device's expected type. Populates
+  // m_rendererParamTypes; leaves it empty when introspection yields nothing.
+  void resolveRendererParamTypes();
+
+  // Apply the CLI renderer parameter overrides to `renderer` (does not commit).
+  // Each value parses into its device-declared type, falling back to inference
+  // when the device does not report the parameter; a value that cannot be
+  // parsed is skipped with a warning.
+  void applyRendererParams(anari::Renderer renderer);
+
   // Write a "missing required feature" skip sidecar for a Case and tally it.
   void writeFeatureSkip(
       const TestDef &test, const Case &c, RunSummary &summary);
@@ -135,6 +153,9 @@ struct Runner
 
   uint32_t m_effectiveAccumulationFrames{1};
   bool m_denoiseEnabled{false};
+  // Declared parameter types for the selected renderer subtype (name -> type),
+  // resolved once from device introspection to type the CLI overrides.
+  std::map<std::string, ANARIDataType> m_rendererParamTypes;
 };
 
 } // namespace cts

--- a/src/anari_test_scenes/cts/Sidecar.cpp
+++ b/src/anari_test_scenes/cts/Sidecar.cpp
@@ -7,6 +7,8 @@
 // std
 #include <atomic>
 #include <fstream>
+#include <limits>
+#include <sstream>
 #include <system_error>
 
 namespace anari {
@@ -38,6 +40,15 @@ const char *verdictName(Verdict v)
     return "skipped";
   }
   return "skipped";
+}
+
+Verdict verdictFromName(const std::string &name)
+{
+  if (name == "passed")
+    return Verdict::Passed;
+  if (name == "failed")
+    return Verdict::Failed;
+  return Verdict::Skipped;
 }
 
 std::string toJson(const CaseResult &result)
@@ -85,6 +96,86 @@ std::string toJson(const CaseResult &result)
   }
 
   return j.dump(2);
+}
+
+namespace {
+
+// A finite number, or NaN for JSON null / non-numbers. The writer emits
+// non-finite scores (e.g. PSNR of identical images) as null; reading them back
+// as NaN keeps them out of numeric comparisons without a separate presence
+// flag.
+double numberOrNan(const json &j)
+{
+  return j.is_number() ? j.get<double>()
+                       : std::numeric_limits<double>::quiet_NaN();
+}
+
+void readMetricMap(const json &obj, std::map<std::string, double> &out)
+{
+  if (!obj.is_object())
+    return;
+  for (const auto &[name, value] : obj.items())
+    out[name] = numberOrNan(value);
+}
+
+} // namespace
+
+bool fromJson(const std::string &text, CaseResult &out, bool *schemaMismatch)
+{
+  json j = json::parse(text, nullptr, /*allow_exceptions=*/false);
+  if (!j.is_object() || !j.contains("verdict"))
+    return false; // not a sidecar
+
+  if (schemaMismatch)
+    *schemaMismatch = j.value("schemaVersion", 0) != kSidecarSchemaVersion;
+
+  out = CaseResult{};
+  out.category = j.value("category", "");
+  out.test = j.value("test", "");
+  out.description = j.value("description", "");
+  out.caseId = j.value("case", "");
+  out.groundTruthKey = j.value("groundTruthKey", "");
+  if (const auto d = j.find("device"); d != j.end() && d->is_object()) {
+    out.device.library = d->value("library", "");
+    out.device.device = d->value("device", "default");
+    out.device.renderer = d->value("renderer", "default");
+  }
+  out.verdict = verdictFromName(j.value("verdict", "skipped"));
+  out.skipReason = j.value("skipReason", "");
+  out.detail = j.value("detail", "");
+  out.durationMs = j.value("durationMs", 0.0);
+
+  if (const auto axes = j.find("axes"); axes != j.end() && axes->is_array())
+    for (const auto &ax : *axes)
+      out.axisValues.emplace_back(ax.value("name", ""), ax.value("value", ""));
+
+  if (const auto chs = j.find("channels"); chs != j.end() && chs->is_array()) {
+    for (const auto &c : *chs) {
+      ChannelResult ch;
+      ch.channel = channelFromName(c.value("channel", "color"));
+      ch.passed = c.value("passed", false);
+      ch.resultImage = c.value("resultImage", "");
+      ch.groundTruthImage = c.value("groundTruthImage", "");
+      ch.diffImage = c.value("diffImage", "");
+      ch.thresholdImage = c.value("thresholdImage", "");
+      readMetricMap(c.value("metrics", json::object()), ch.metrics);
+      readMetricMap(c.value("thresholds", json::object()), ch.thresholds);
+      out.channels.push_back(std::move(ch));
+    }
+  }
+
+  return true;
+}
+
+bool readSidecar(
+    const std::filesystem::path &path, CaseResult &out, bool *schemaMismatch)
+{
+  std::ifstream in(path);
+  if (!in)
+    return false;
+  std::stringstream buffer;
+  buffer << in.rdbuf();
+  return fromJson(buffer.str(), out, schemaMismatch);
 }
 
 bool writeSidecar(const std::filesystem::path &path, const CaseResult &result)

--- a/src/anari_test_scenes/cts/Sidecar.h
+++ b/src/anari_test_scenes/cts/Sidecar.h
@@ -37,6 +37,10 @@ enum class Verdict
 
 const char *verdictName(Verdict v);
 
+// Parse a verdict name; unknown names read as Skipped (best-effort, matching
+// the Python reader's default).
+Verdict verdictFromName(const std::string &name);
+
 // Which device produced a run, by the names the CLI loaded it with: the ANARI
 // library, the device subtype, and the selected renderer subtype. For a suite
 // whose purpose is comparing devices, this is what labels a run.
@@ -86,6 +90,19 @@ std::string toJson(const CaseResult &result);
 // Write the sidecar through a temporary sibling and atomically rename it into
 // place, creating parent directories. False on failure.
 bool writeSidecar(const std::filesystem::path &path, const CaseResult &result);
+
+// Parse sidecar JSON text into a CaseResult. Returns false when the text is not
+// a sidecar (invalid JSON or missing the `verdict` field). Optional fields read
+// with defaults, so older schema versions parse best-effort; when
+// `schemaMismatch` is non-null it is set true if the text's schemaVersion
+// differs from kSidecarSchemaVersion.
+bool fromJson(
+    const std::string &text, CaseResult &out, bool *schemaMismatch = nullptr);
+
+// Read and parse a sidecar file. False when unreadable or not a sidecar.
+bool readSidecar(const std::filesystem::path &path,
+    CaseResult &out,
+    bool *schemaMismatch = nullptr);
 
 } // namespace cts
 } // namespace anari

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(anariCatalogTests
   test_cts_catalog.cpp
   test_cts_deviceinfo.cpp
   test_cts_metrics.cpp
+  test_cts_report.cpp
   test_cts_results.cpp
   test_cts_runner.cpp
   test_cts_worldbuilder.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(anariCatalogTests
   test_cts_catalog.cpp
   test_cts_deviceinfo.cpp
   test_cts_metrics.cpp
+  test_cts_rendererparams.cpp
   test_cts_report.cpp
   test_cts_results.cpp
   test_cts_runner.cpp

--- a/tests/unit/test_cts_rendererparams.cpp
+++ b/tests/unit/test_cts_rendererparams.cpp
@@ -1,0 +1,126 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "catch.hpp"
+// cts
+#include "cts/RendererParams.h"
+// std
+#include <cstdint>
+#include <cstring>
+
+using namespace anari::cts;
+
+namespace {
+
+template <typename T>
+T as(const ParsedParam &p)
+{
+  T v{};
+  std::memcpy(&v, p.bytes.data(), sizeof(T));
+  return v;
+}
+
+} // namespace
+
+TEST_CASE("parseRendererParam splits on the first '='", "[cts]")
+{
+  auto p = parseRendererParam("ambientSample=4");
+  REQUIRE(p);
+  CHECK(p->name == "ambientSample");
+  CHECK(p->value == "4");
+
+  SECTION("value may contain '='")
+  {
+    auto q = parseRendererParam("expr=a=b");
+    REQUIRE(q);
+    CHECK(q->name == "expr");
+    CHECK(q->value == "a=b");
+  }
+
+  SECTION("surrounding whitespace on the name is trimmed")
+  {
+    auto q = parseRendererParam("  name = value");
+    REQUIRE(q);
+    CHECK(q->name == "name");
+    CHECK(q->value == " value");
+  }
+
+  SECTION("missing '=' or empty name is rejected")
+  {
+    CHECK_FALSE(parseRendererParam("noequals"));
+    CHECK_FALSE(parseRendererParam("=value"));
+  }
+}
+
+TEST_CASE("inferParamType picks the narrowest matching type", "[cts]")
+{
+  CHECK(inferParamType("true") == ANARI_BOOL);
+  CHECK(inferParamType("false") == ANARI_BOOL);
+  CHECK(inferParamType("4") == ANARI_INT32);
+  CHECK(inferParamType("-7") == ANARI_INT32);
+  CHECK(inferParamType("1.5") == ANARI_FLOAT32);
+  CHECK(inferParamType("1,2") == ANARI_FLOAT32_VEC2);
+  CHECK(inferParamType("1,2,3") == ANARI_FLOAT32_VEC3);
+  CHECK(inferParamType("1,2,3,4") == ANARI_FLOAT32_VEC4);
+  CHECK(inferParamType("red") == ANARI_STRING);
+  CHECK(inferParamType("1,2,3,4,5") == ANARI_STRING); // no 5-vector
+  CHECK(inferParamType("a,b") == ANARI_STRING); // non-numeric list
+}
+
+TEST_CASE("parseParamValue honors the declared type", "[cts]")
+{
+  SECTION("int declared type parses an integer value")
+  {
+    auto p = parseParamValue(ANARI_INT32, "4");
+    REQUIRE(p);
+    CHECK(p->type == ANARI_INT32);
+    CHECK(as<int32_t>(*p) == 4);
+  }
+
+  SECTION("float declared type accepts an integer-looking value")
+  {
+    auto p = parseParamValue(ANARI_FLOAT32, "4");
+    REQUIRE(p);
+    CHECK(p->type == ANARI_FLOAT32);
+    CHECK(as<float>(*p) == 4.f);
+  }
+
+  SECTION("bool accepts true/false and 1/0")
+  {
+    CHECK(as<int8_t>(*parseParamValue(ANARI_BOOL, "true")) == 1);
+    CHECK(as<int8_t>(*parseParamValue(ANARI_BOOL, "0")) == 0);
+    CHECK_FALSE(parseParamValue(ANARI_BOOL, "yes"));
+  }
+
+  SECTION("uint rejects negatives")
+  {
+    CHECK(parseParamValue(ANARI_UINT32, "5"));
+    CHECK_FALSE(parseParamValue(ANARI_UINT32, "-1"));
+  }
+
+  SECTION("float vector requires the exact component count")
+  {
+    auto p = parseParamValue(ANARI_FLOAT32_VEC3, "1,2,3");
+    REQUIRE(p);
+    CHECK(as<float>(*p) == 1.f);
+    CHECK_FALSE(parseParamValue(ANARI_FLOAT32_VEC3, "1,2"));
+  }
+
+  SECTION("string is NUL-terminated")
+  {
+    auto p = parseParamValue(ANARI_STRING, "sobol");
+    REQUIRE(p);
+    CHECK(std::strcmp(reinterpret_cast<const char *>(p->bytes.data()), "sobol")
+        == 0);
+  }
+}
+
+TEST_CASE("parseParamValue infers when type is unknown", "[cts]")
+{
+  auto p = parseParamValue(ANARI_UNKNOWN, "4");
+  REQUIRE(p);
+  CHECK(p->type == ANARI_INT32);
+
+  CHECK_FALSE(parseParamValue(ANARI_INT32, "1.5")); // declared int, float text
+  CHECK_FALSE(parseParamValue(ANARI_FLOAT32, "abc"));
+}

--- a/tests/unit/test_cts_report.cpp
+++ b/tests/unit/test_cts_report.cpp
@@ -1,0 +1,253 @@
+// Copyright 2021-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "catch.hpp"
+// cts
+#include "cts/HtmlReport.h"
+#include "cts/Report.h"
+#include "cts/Sidecar.h"
+#include "cts/Workdir.h"
+// std
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <sstream>
+
+using namespace anari::cts;
+
+namespace {
+
+CaseResult makeCase(const std::string &category,
+    const std::string &test,
+    const std::string &caseId,
+    Verdict verdict)
+{
+  CaseResult r;
+  r.category = category;
+  r.test = test;
+  r.caseId = caseId;
+  r.device = {"helide", "default", "default"};
+  r.verdict = verdict;
+  return r;
+}
+
+ChannelResult colorChannel(double ssim, bool passed)
+{
+  ChannelResult ch;
+  ch.channel = Channel::Color;
+  ch.metrics = {{"ssim", ssim}, {"psnr", 30.0}};
+  ch.thresholds = {{"ssim", 0.7}, {"psnr", 20.0}};
+  ch.passed = passed;
+  return ch;
+}
+
+std::map<std::string, CaseResult> keyed(std::vector<CaseResult> cases)
+{
+  std::map<std::string, CaseResult> out;
+  for (auto &c : cases)
+    out.emplace(c.category + "/" + c.test + "/" + c.caseId, std::move(c));
+  return out;
+}
+
+} // namespace
+
+// Sidecar reader /////////////////////////////////////////////////////////////
+
+TEST_CASE("fromJson round-trips a written sidecar", "[cts][sidecar]")
+{
+  CaseResult r = makeCase("geometry", "sphere", "1_soup", Verdict::Passed);
+  r.description = "Checks sphere geometry.";
+  r.groundTruthKey = "1";
+  r.axisValues = {{"primitiveCount", "1"}, {"primitiveMode", "soup"}};
+  r.durationMs = 12.5;
+  ChannelResult ch = colorChannel(0.95, true);
+  ch.resultImage = "results/geometry/sphere/1_soup.color.png";
+  ch.groundTruthImage = "ground_truth/geometry/sphere/1.color.png";
+  r.channels.push_back(ch);
+
+  CaseResult back;
+  bool mismatch = true;
+  REQUIRE(fromJson(toJson(r), back, &mismatch));
+  CHECK_FALSE(mismatch);
+  CHECK(back.category == "geometry");
+  CHECK(back.test == "sphere");
+  CHECK(back.caseId == "1_soup");
+  CHECK(back.description == "Checks sphere geometry.");
+  CHECK(back.device.library == "helide");
+  CHECK(back.verdict == Verdict::Passed);
+  CHECK(back.durationMs == Approx(12.5));
+  REQUIRE(back.axisValues.size() == 2);
+  CHECK(back.axisValues[0].first == "primitiveCount");
+  REQUIRE(back.channels.size() == 1);
+  CHECK(back.channels[0].channel == Channel::Color);
+  CHECK(back.channels[0].metrics.at("ssim") == Approx(0.95));
+  CHECK(back.channels[0].resultImage
+      == "results/geometry/sphere/1_soup.color.png");
+}
+
+TEST_CASE("fromJson rejects a non-sidecar document", "[cts][sidecar]")
+{
+  CaseResult r;
+  CHECK_FALSE(fromJson("{\"hello\": 1}", r));
+  CHECK_FALSE(fromJson("not json", r));
+}
+
+TEST_CASE("fromJson reads a null metric as non-finite", "[cts][sidecar]")
+{
+  CaseResult r;
+  REQUIRE(
+      fromJson("{\"verdict\":\"passed\",\"channels\":[{\"channel\":\"color\","
+               "\"metrics\":{\"psnr\":null}}]}",
+          r));
+  REQUIRE(r.channels.size() == 1);
+  CHECK_FALSE(std::isfinite(r.channels[0].metrics.at("psnr")));
+}
+
+// Aggregation ////////////////////////////////////////////////////////////////
+
+TEST_CASE("summarize counts overall and per category", "[cts][report]")
+{
+  auto results = keyed({
+      makeCase("geometry", "sphere", "a", Verdict::Passed),
+      makeCase("geometry", "cone", "b", Verdict::Failed),
+      makeCase("light", "directional", "c", Verdict::Skipped),
+  });
+
+  const Summary s = summarize(results);
+  CHECK(s.total == 3);
+  CHECK(s.passed == 1);
+  CHECK(s.failed == 1);
+  CHECK(s.skipped == 1);
+  CHECK(s.categories.at("geometry").passed == 1);
+  CHECK(s.categories.at("geometry").failed == 1);
+  CHECK(s.categories.at("light").skipped == 1);
+  REQUIRE(s.failures.size() == 1);
+  CHECK(s.failures[0] == "geometry/cone/b");
+}
+
+TEST_CASE(
+    "runDevice returns the shared identity, none when mixed", "[cts][report]")
+{
+  std::ostringstream warnings;
+  auto same = keyed({makeCase("geometry", "sphere", "a", Verdict::Passed),
+      makeCase("light", "point", "b", Verdict::Passed)});
+  const auto device = runDevice(same, warnings);
+  REQUIRE(device.has_value());
+  CHECK(device->library == "helide");
+  CHECK(warnings.str().empty());
+
+  auto mixed = same;
+  CaseResult other = makeCase("volume", "field", "c", Verdict::Passed);
+  other.device.library = "othurdevice";
+  mixed.emplace("volume/field/c", other);
+  std::ostringstream warnings2;
+  CHECK_FALSE(runDevice(mixed, warnings2).has_value());
+  CHECK(warnings2.str().find("mixed device") != std::string::npos);
+}
+
+// Encoding helpers ///////////////////////////////////////////////////////////
+
+TEST_CASE("base64Encode matches RFC 4648 test vectors", "[cts][html]")
+{
+  CHECK(base64Encode("") == "");
+  CHECK(base64Encode("f") == "Zg==");
+  CHECK(base64Encode("fo") == "Zm8=");
+  CHECK(base64Encode("foo") == "Zm9v");
+  CHECK(base64Encode("foob") == "Zm9vYg==");
+  CHECK(base64Encode("fooba") == "Zm9vYmE=");
+  CHECK(base64Encode("foobar") == "Zm9vYmFy");
+}
+
+TEST_CASE("htmlEscape neutralizes markup", "[cts][html]")
+{
+  CHECK(htmlEscape("<a href=\"x\">&'</a>")
+      == "&lt;a href=&quot;x&quot;&gt;&amp;&#39;&lt;/a&gt;");
+}
+
+// HTML document //////////////////////////////////////////////////////////////
+
+TEST_CASE("generateHtml embeds summary, cases, and behavior", "[cts][html]")
+{
+  auto results = keyed({
+      makeCase("geometry", "sphere", "a", Verdict::Passed),
+      makeCase("geometry", "cone", "b", Verdict::Failed),
+  });
+
+  HtmlOptions opts; // failures-only initial view
+  const std::string doc = generateHtml("/tmp/myrun", results, opts);
+
+  CHECK(doc.find("<!DOCTYPE html>") != std::string::npos);
+  CHECK(doc.find("helide (default/default)") != std::string::npos);
+  CHECK(doc.find("geometry/cone/b") != std::string::npos);
+  CHECK(doc.find("data-verdict=\"failed\"") != std::string::npos);
+  CHECK(doc.find("data-verdict=\"passed\"") != std::string::npos); // metadata
+  CHECK(doc.find("data-key=\"geometry/cone/b\"") != std::string::npos);
+  CHECK(doc.find("applyFilter") != std::string::npos); // the script shipped
+
+  // Category groups carry a deep-link anchor.
+  CHECK(doc.find("id=\"cat-geometry\"") != std::string::npos);
+}
+
+TEST_CASE(
+    "generateHtml references images relative to the html file", "[cts][html]")
+{
+  const auto root = std::filesystem::temp_directory_path() / "cts_htmlsrc_test";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  const auto imgDir = root / "run" / "results" / "geometry" / "cone";
+  REQUIRE(std::filesystem::create_directories(imgDir));
+  std::ofstream(imgDir / "b.color.png") << "png";
+
+  CaseResult failed = makeCase("geometry", "cone", "b", Verdict::Failed);
+  ChannelResult ch = colorChannel(0.1, false);
+  ch.resultImage = "results/geometry/cone/b.color.png";
+  failed.channels = {ch};
+  const auto results = keyed({failed});
+
+  // A document outside the workdir reaches images through the workdir.
+  HtmlOptions opts;
+  opts.htmlPath = root / "reports" / "index.html";
+  const std::string doc = generateHtml(root / "run", results, opts);
+  CHECK(doc.find("src=\"../run/results/geometry/cone/b.color.png\"")
+      != std::string::npos);
+
+  // A document in the workdir root keeps the workdir-relative reference.
+  HtmlOptions inRoot;
+  inRoot.htmlPath = root / "run" / "report.html";
+  const std::string rootDoc = generateHtml(root / "run", results, inRoot);
+  CHECK(rootDoc.find("src=\"results/geometry/cone/b.color.png\"")
+      != std::string::npos);
+
+  // No destination: the legacy workdir-relative reference is preserved.
+  const std::string bare = generateHtml(root / "run", results, HtmlOptions{});
+  CHECK(bare.find("src=\"results/geometry/cone/b.color.png\"")
+      != std::string::npos);
+
+  std::filesystem::remove_all(root, ec);
+}
+
+// Results tree loading ///////////////////////////////////////////////////////
+
+TEST_CASE("loadResults globs the results tree", "[cts][report]")
+{
+  const auto root =
+      std::filesystem::temp_directory_path() / "cts_loadresults_test";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+
+  const Workdir wd(root);
+  Case c;
+  c.category = "geometry";
+  c.testName = "sphere";
+  c.values = {{"primitiveCount", Any(1), AxisKind::Permutation}};
+  CaseResult r = makeCase("geometry", "sphere", c.id(), Verdict::Failed);
+  REQUIRE(writeSidecar(wd.sidecarPath(c), r));
+
+  std::ostringstream warnings;
+  auto results = loadResults(root, warnings);
+  REQUIRE(results.size() == 1);
+  CHECK(results.begin()->second.verdict == Verdict::Failed);
+
+  std::filesystem::remove_all(root, ec);
+}


### PR DESCRIPTION
Sister output to the current PDF one, generates and interactive HTML report.