### PR TITLE
hdanari: improve MDL material support and harden the hdAnari Hydra delegate

### DIFF
--- a/src/hdanari/mdl/mdlRegistry.cpp
+++ b/src/hdanari/mdl/mdlRegistry.cpp
@@ -72,35 +72,45 @@ TF_INSTANTIATE_SINGLETON(HdAnariMdlRegistry);
 
 HdAnariMdlRegistry *HdAnariMdlRegistry::GetInstance()
 {
-  try {
-    return &TfSingleton<HdAnariMdlRegistry>::GetInstance();
-  } catch (const std::exception &e) {
-    TF_RUNTIME_ERROR("Failed to create MdlRegistry singleton.");
-    return nullptr;
-  }
+  // Construction never throws (see the constructors): on failure it publishes a
+  // disabled instance whose getINeuray() is null. No try/catch here -- swallowing
+  // a construction throw would leave TfSingleton wedged (isInitializing set,
+  // instance null) and hang every later call.
+  return &TfSingleton<HdAnariMdlRegistry>::GetInstance();
 }
 
 mi::neuraylib::INeuray *HdAnariMdlRegistry::AcquireNeuray(DllHandle dllHandle)
 {
+  // Return null (don't throw) on failure: callers build a disabled registry
+  // rather than letting an exception escape the singleton ctor.
+  if (dllHandle == nullptr) {
+    TF_RUNTIME_ERROR("MDL SDK library is not loaded");
+    return nullptr;
+  }
+
   // Get neuray main entry point
   auto symbol = getProcAddress(dllHandle, "mi_factory");
-  if (symbol == nullptr)
-    throw std::runtime_error("Failed to find MDL SDK mi_factory symbol");
+  if (symbol == nullptr) {
+    TF_RUNTIME_ERROR("Failed to find MDL SDK mi_factory symbol");
+    return nullptr;
+  }
 
   auto neuray = mi::neuraylib::mi_factory<mi::neuraylib::INeuray>(symbol);
   if (neuray == nullptr) {
-    // Check if we have a valid neuray instance, otherwise check why.
+    // INeuray can be acquired only once per process; a null here usually means
+    // another subsystem (e.g. the VisRTX device) already holds it, or a version
+    // mismatch.
     auto version =
         make_handle(mi::neuraylib::mi_factory<mi::neuraylib::IVersion>(symbol));
-    if (!version) {
-      throw std::runtime_error("Cannot get MDL SDK library version");
-    } else {
-      throw std::runtime_error(
-          "Cannot get INeuray interface from mi_factory, either there is a version mismatch or the interface has already been acquired: "s
-          "Expected version is " MI_NEURAYLIB_PRODUCT_VERSION_STRING
-          ", library version is "
-          + version->get_product_version());
-    }
+    if (!version)
+      TF_RUNTIME_ERROR("Cannot get MDL SDK library version");
+    else
+      TF_RUNTIME_ERROR(
+          "Cannot get INeuray: version mismatch or the interface is already "
+          "acquired (expected %s, library %s)",
+          MI_NEURAYLIB_PRODUCT_VERSION_STRING,
+          version->get_product_version());
+    return nullptr;
   }
 
   return neuray;
@@ -141,10 +151,7 @@ HdAnariMdlRegistry::HdAnariMdlRegistry(DllHandle dllHandle)
     : HdAnariMdlRegistry(dllHandle, AcquireNeuray(dllHandle))
 {}
 
-HdAnariMdlRegistry::HdAnariMdlRegistry(DllHandle dllHandle,
-    mi::neuraylib::INeuray *neuray,
-    mi::base::ILogger *logger)
-    : m_dllHandle(dllHandle), m_neuray(neuray)
+void HdAnariMdlRegistry::_Initialize(mi::base::ILogger *logger)
 {
   // Get the MDL configuration component so main path can be added.
   auto mdlConfiguration = make_handle(
@@ -204,6 +211,14 @@ HdAnariMdlRegistry::HdAnariMdlRegistry(DllHandle dllHandle,
   if (!m_globalScope.is_valid_interface())
     throw std::runtime_error("Failed to acquire neuray database global scope");
 
+  // Isolate our introspection work from any other consumer of this shared
+  // INeuray (e.g. the VisRTX device): use a private child scope rather than
+  // the global one.
+  m_introspectionScope =
+      make_handle(database->create_scope(m_globalScope.get()));
+  if (!m_introspectionScope.is_valid_interface())
+    throw std::runtime_error("Failed to create MDL introspection scope");
+
   // Get an execution context for later use.
   m_mdlFactory =
       make_handle(m_neuray->get_api_component<mi::neuraylib::IMdl_factory>());
@@ -215,7 +230,35 @@ HdAnariMdlRegistry::HdAnariMdlRegistry(DllHandle dllHandle,
   if (!m_executionContext.is_valid_interface()) {
     throw std::runtime_error("Failed acquiring an execution context");
   }
+}
 
+HdAnariMdlRegistry::HdAnariMdlRegistry(DllHandle dllHandle,
+    mi::neuraylib::INeuray *neuray,
+    mi::base::ILogger *logger)
+    : m_dllHandle(dllHandle), m_neuray(neuray)
+{
+  // Never let an exception escape this ctor: one that escapes TfSingleton's
+  // construction leaves isInitializing=true / instance=null forever, so every
+  // later GetInstance() spins (deadlock). On failure publish a disabled
+  // registry (getINeuray()==null) and let callers fall back.
+  try {
+    if (!m_neuray)
+      throw std::runtime_error(
+          "MDL INeuray unavailable (acquisition failed, or already held by "
+          "another subsystem)");
+    _Initialize(logger);
+  } catch (const std::exception &e) {
+    TF_RUNTIME_ERROR("HdAnariMdlRegistry disabled: %s", e.what());
+    m_executionContext = {};
+    m_mdlFactory = {};
+    m_introspectionScope = {};
+    m_globalScope = {};
+    m_neuray = {};
+    if (m_dllHandle) {
+      freeLibrary(m_dllHandle);
+      m_dllHandle = {};
+    }
+  }
   TfSingleton<HdAnariMdlRegistry>::SetInstanceConstructed(*this);
 }
 
@@ -223,8 +266,9 @@ HdAnariMdlRegistry::~HdAnariMdlRegistry()
 {
   m_executionContext = {};
   m_mdlFactory = {};
+  m_introspectionScope = {};
   m_globalScope = {};
-  if (m_dllHandle) {
+  if (m_dllHandle && m_neuray) {
     m_neuray->shutdown();
     m_neuray = {};
     freeLibrary(m_dllHandle);
@@ -253,7 +297,7 @@ auto HdAnariMdlRegistry::createTransaction(mi::neuraylib::IScope *scope)
     -> mi::neuraylib::ITransaction *
 {
   if (!scope)
-    scope = m_globalScope.get();
+    scope = m_introspectionScope.get();
   return scope->create_transaction();
 }
 

--- a/src/hdanari/mdl/mdlRegistry.cpp
+++ b/src/hdanari/mdl/mdlRegistry.cpp
@@ -47,6 +47,9 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
+
+#include <pxr/base/tf/diagnostic.h>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -300,8 +303,31 @@ auto HdAnariMdlRegistry::loadModule(std::string_view moduleOrFileName,
 
   if (impexpApi->load_module(
           transaction, moduleName.c_str(), m_executionContext.get())
-      < 0)
+      < 0) {
+    // Surface *why* the module failed, once per module. Otherwise the MDL
+    // compiler errors (e.g. C120 unresolved imports from a missing search
+    // path) are buried in SDK output and every dependent material only reports
+    // a generic "parser returned null" -- 800+ identical lines for one missing
+    // package.
+    static std::unordered_set<std::string> reported;
+    if (reported.insert(moduleName).second) {
+      std::string errors;
+      for (auto i = 0ull,
+                n = m_executionContext->get_error_messages_count();
+          i < n;
+          ++i) {
+        auto message = make_handle(m_executionContext->get_error_message(i));
+        errors += "\n  ";
+        errors += message->get_string();
+      }
+      TF_WARN(
+          "MDL module '%s' failed to load; dependent materials will be "
+          "skipped. Check MDL search paths (MDL_SYSTEM_PATH/MDL_USER_PATH).%s",
+          moduleName.c_str(),
+          errors.c_str());
+    }
     return {};
+  }
 
   // Get the database name for the module we loaded
   auto moduleDbName = make_handle(

--- a/src/hdanari/mdl/mdlRegistry.cpp
+++ b/src/hdanari/mdl/mdlRegistry.cpp
@@ -46,6 +46,7 @@
 #include <cstdio>
 #include <exception>
 #include <filesystem>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -73,9 +74,9 @@ TF_INSTANTIATE_SINGLETON(HdAnariMdlRegistry);
 HdAnariMdlRegistry *HdAnariMdlRegistry::GetInstance()
 {
   // Construction never throws (see the constructors): on failure it publishes a
-  // disabled instance whose getINeuray() is null. No try/catch here -- swallowing
-  // a construction throw would leave TfSingleton wedged (isInitializing set,
-  // instance null) and hang every later call.
+  // disabled instance whose getINeuray() is null. No try/catch here --
+  // swallowing a construction throw would leave TfSingleton wedged
+  // (isInitializing set, instance null) and hang every later call.
   return &TfSingleton<HdAnariMdlRegistry>::GetInstance();
 }
 
@@ -266,6 +267,15 @@ HdAnariMdlRegistry::~HdAnariMdlRegistry()
 {
   m_executionContext = {};
   m_mdlFactory = {};
+  // Remove our private introspection scope from the database. When we own
+  // neuray the shutdown below tears everything down anyway, but for a shared
+  // INeuray (m_dllHandle == nullptr) neuray outlives us, so the scope would
+  // otherwise leak in the shared database.
+  if (m_neuray && m_introspectionScope) {
+    if (auto database = make_handle(
+            m_neuray->get_api_component<mi::neuraylib::IDatabase>()))
+      database->remove_scope(m_introspectionScope->get_id());
+  }
   m_introspectionScope = {};
   m_globalScope = {};
   if (m_dllHandle && m_neuray) {
@@ -279,6 +289,8 @@ HdAnariMdlRegistry::~HdAnariMdlRegistry()
 auto HdAnariMdlRegistry::createScope(std::string_view scopeName,
     mi::neuraylib::IScope *parent) -> mi::neuraylib::IScope *
 {
+  if (!m_neuray)
+    return {}; // disabled registry
   auto database =
       make_handle(m_neuray->get_api_component<mi::neuraylib::IDatabase>());
 
@@ -287,6 +299,8 @@ auto HdAnariMdlRegistry::createScope(std::string_view scopeName,
 
 auto HdAnariMdlRegistry::removeScope(mi::neuraylib::IScope *scope) -> void
 {
+  if (!m_neuray || !scope)
+    return;
   auto database =
       make_handle(m_neuray->get_api_component<mi::neuraylib::IDatabase>());
 
@@ -298,11 +312,15 @@ auto HdAnariMdlRegistry::createTransaction(mi::neuraylib::IScope *scope)
 {
   if (!scope)
     scope = m_introspectionScope.get();
+  if (!scope)
+    return {}; // disabled registry: no introspection scope to transact on
   return scope->create_transaction();
 }
 
 auto HdAnariMdlRegistry::preprendUserSearchPath(std::string_view path) -> void
 {
+  if (!m_neuray)
+    return; // disabled registry
   auto mdlConfiguration = make_handle(
       m_neuray->get_api_component<mi::neuraylib::IMdl_configuration>());
 
@@ -325,6 +343,8 @@ auto HdAnariMdlRegistry::preprendUserSearchPath(std::string_view path) -> void
 auto HdAnariMdlRegistry::loadModuleByCanonicalName(std::string_view filePath,
     mi::neuraylib::ITransaction *transaction) -> const mi::neuraylib::IModule *
 {
+  if (!m_neuray)
+    return {}; // disabled registry
   std::string path(filePath);
   if (path.find('/') == std::string::npos)
     return {}; // already a module name, nothing to recover
@@ -342,11 +362,10 @@ auto HdAnariMdlRegistry::loadModuleByCanonicalName(std::string_view filePath,
   // co-located, instead of the incomplete local file.
   auto pathsCount = mdlConfiguration->get_mdl_paths_length();
   for (auto i = decltype(pathsCount)(0); i < pathsCount; ++i) {
-    auto rootName =
-        std::filesystem::path(
-            make_handle(mdlConfiguration->get_mdl_path(i))->get_c_str())
-            .filename()
-            .string();
+    auto rootName = std::filesystem::path(
+        make_handle(mdlConfiguration->get_mdl_path(i))->get_c_str())
+                        .filename()
+                        .string();
     if (rootName.empty())
       continue;
 
@@ -390,6 +409,8 @@ auto HdAnariMdlRegistry::loadModuleByCanonicalName(std::string_view filePath,
 auto HdAnariMdlRegistry::loadModule(std::string_view moduleOrFileName,
     mi::neuraylib::ITransaction *transaction) -> const mi::neuraylib::IModule *
 {
+  if (!m_neuray)
+    return {}; // disabled registry
   auto impexpApi = make_handle(
       m_neuray->get_api_component<mi::neuraylib::IMdl_impexp_api>());
 
@@ -411,8 +432,12 @@ auto HdAnariMdlRegistry::loadModule(std::string_view moduleOrFileName,
     moduleName = name->get_c_str();
   }
 
+  // Use a local execution context, not the shared m_executionContext: the SDR
+  // parser and <mdl> backend call loadModule from Hydra worker threads, and a
+  // shared context would race on its error state.
+  auto context = make_handle(m_mdlFactory->create_execution_context());
   if (impexpApi->load_module(
-          transaction, moduleName.c_str(), m_executionContext.get())
+          transaction, moduleName.c_str(), context.get())
       < 0) {
     // A scene may ship a .mdl without its resources (e.g. a vMaterials module
     // copied without its ./textures), so the local copy fails to compile.
@@ -427,14 +452,15 @@ auto HdAnariMdlRegistry::loadModule(std::string_view moduleOrFileName,
     // path) are buried in SDK output and every dependent material only reports
     // a generic "parser returned null" -- 800+ identical lines for one missing
     // package.
+    static std::mutex reportedMutex;
     static std::unordered_set<std::string> reported;
+    std::lock_guard<std::mutex> reportedGuard(reportedMutex);
     if (reported.insert(moduleName).second) {
       std::string errors;
-      for (auto i = 0ull,
-                n = m_executionContext->get_error_messages_count();
+      for (auto i = 0ull, n = context->get_error_messages_count();
           i < n;
           ++i) {
-        auto message = make_handle(m_executionContext->get_error_message(i));
+        auto message = make_handle(context->get_error_message(i));
         errors += "\n  ";
         errors += message->get_string();
       }
@@ -459,6 +485,8 @@ auto HdAnariMdlRegistry::getFunctionDefinition(
     mi::neuraylib::ITransaction *transaction)
     -> const mi::neuraylib::IFunction_definition *
 {
+  if (!module || functionName.empty())
+    return {};
   std::string functionQualifiedName;
   if (functionName.back()
       == ')') // Already a full qualified function signature.

--- a/src/hdanari/mdl/mdlRegistry.cpp
+++ b/src/hdanari/mdl/mdlRegistry.cpp
@@ -45,6 +45,7 @@
 #include <array>
 #include <cstdio>
 #include <exception>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -277,6 +278,71 @@ auto HdAnariMdlRegistry::preprendUserSearchPath(std::string_view path) -> void
   }
 }
 
+auto HdAnariMdlRegistry::loadModuleByCanonicalName(std::string_view filePath,
+    mi::neuraylib::ITransaction *transaction) -> const mi::neuraylib::IModule *
+{
+  std::string path(filePath);
+  if (path.find('/') == std::string::npos)
+    return {}; // already a module name, nothing to recover
+
+  auto impexpApi = make_handle(
+      m_neuray->get_api_component<mi::neuraylib::IMdl_impexp_api>());
+  auto mdlConfiguration = make_handle(
+      m_neuray->get_api_component<mi::neuraylib::IMdl_configuration>());
+
+  // If the failing path passes through a directory whose basename matches a
+  // search root (e.g. ".../vMaterials_2/Concrete/Concrete_Precast.mdl" with a
+  // "/data/mdl/vMaterials_2" root), the canonical module name is the tail after
+  // it ("::Concrete::Concrete_Precast"). Loading that by name lets the entity
+  // resolver pick a complete copy on the search path, with its resources
+  // co-located, instead of the incomplete local file.
+  auto pathsCount = mdlConfiguration->get_mdl_paths_length();
+  for (auto i = decltype(pathsCount)(0); i < pathsCount; ++i) {
+    auto rootName =
+        std::filesystem::path(
+            make_handle(mdlConfiguration->get_mdl_path(i))->get_c_str())
+            .filename()
+            .string();
+    if (rootName.empty())
+      continue;
+
+    auto marker = "/" + rootName + "/";
+    auto pos = path.rfind(marker);
+    if (pos == std::string::npos)
+      continue;
+
+    auto tail = path.substr(pos + marker.size());
+    if (auto n = tail.size(); n > 4 && tail.substr(n - 4) == ".mdl")
+      tail = tail.substr(0, n - 4);
+    if (tail.empty())
+      continue;
+
+    std::string moduleName = "::";
+    for (char c : tail)
+      moduleName += (c == '/') ? "::"s : std::string(1, c);
+
+    auto context = make_handle(m_mdlFactory->create_execution_context());
+    if (impexpApi->load_module(transaction, moduleName.c_str(), context.get())
+        < 0)
+      continue;
+
+    auto moduleDbName =
+        make_handle(m_mdlFactory->get_db_module_name(moduleName.c_str()));
+    if (auto *module = transaction->access<mi::neuraylib::IModule>(
+            moduleDbName->get_c_str())) {
+      if (m_logger)
+        m_logger->message(mi::base::MESSAGE_SEVERITY_INFO,
+            "hdanari::mdl",
+            ("Recovered '"s + path + "' from the MDL search path as '"
+                + moduleName + "'")
+                .c_str());
+      return module;
+    }
+  }
+
+  return {};
+}
+
 auto HdAnariMdlRegistry::loadModule(std::string_view moduleOrFileName,
     mi::neuraylib::ITransaction *transaction) -> const mi::neuraylib::IModule *
 {
@@ -304,6 +370,14 @@ auto HdAnariMdlRegistry::loadModule(std::string_view moduleOrFileName,
   if (impexpApi->load_module(
           transaction, moduleName.c_str(), m_executionContext.get())
       < 0) {
+    // A scene may ship a .mdl without its resources (e.g. a vMaterials module
+    // copied without its ./textures), so the local copy fails to compile.
+    // A complete copy usually exists on the MDL search path -- recover it by
+    // canonical name before giving up.
+    if (auto *recovered =
+            loadModuleByCanonicalName(moduleOrFileName, transaction))
+      return recovered;
+
     // Surface *why* the module failed, once per module. Otherwise the MDL
     // compiler errors (e.g. C120 unresolved imports from a missing search
     // path) are buried in SDK output and every dependent material only reports

--- a/src/hdanari/mdl/mdlRegistry.h
+++ b/src/hdanari/mdl/mdlRegistry.h
@@ -108,9 +108,20 @@ class HDANARI_MDL_API HdAnariMdlRegistry
 
   ~HdAnariMdlRegistry();
 
+  // Heavy, fallible neuray setup (components, plugins, start, scopes, factory).
+  // May throw; the constructors call it inside a try/catch so a failure yields
+  // a disabled registry instead of an exception escaping TfSingleton's
+  // construction (which would wedge the singleton and hang every GetInstance).
+  void _Initialize(mi::base::ILogger *logger);
+
   DllHandle m_dllHandle;
   mi::base::Handle<mi::neuraylib::INeuray> m_neuray;
   mi::base::Handle<mi::neuraylib::IScope> m_globalScope;
+  // Dedicated child scope for our own module introspection. Keeps our
+  // transactions isolated from any other consumer of this shared INeuray
+  // instance (e.g. the VisRTX device), so loading/aborting modules here can
+  // never disturb their view of the database.
+  mi::base::Handle<mi::neuraylib::IScope> m_introspectionScope;
   mi::base::Handle<mi::neuraylib::IMdl_factory> m_mdlFactory;
   mi::base::Handle<mi::neuraylib::IMdl_execution_context> m_executionContext;
   mi::base::Handle<mi::base::ILogger> m_logger;

--- a/src/hdanari/mdl/mdlRegistry.h
+++ b/src/hdanari/mdl/mdlRegistry.h
@@ -63,7 +63,21 @@ class HDANARI_MDL_API HdAnariMdlRegistry
       -> mi::neuraylib::ITransaction *;
 
   auto preprendUserSearchPath(std::string_view path) -> void;
+  // Returns a +1-retained IModule owned by the caller: adopt it into an
+  // mi::base::Handle (as ProcessMdlNode does) so it is released before the
+  // transaction closes. Null on failure. Same contract for
+  // loadModuleByCanonicalName and getFunctionDefinition below.
   auto loadModule(std::string_view moduleOrFileName,
+      mi::neuraylib::ITransaction *transaction)
+      -> const mi::neuraylib::IModule *;
+
+  // Fallback for a path-based load that failed (e.g. a scene shipped a .mdl
+  // without its ./textures). If the path passes through a directory whose
+  // basename matches an MDL search root, derive the canonical module name from
+  // the tail and load it by name, so the entity resolver finds a complete copy
+  // on the search path with its resources co-located. Returns null if no
+  // search-root segment matches or the named module still fails.
+  auto loadModuleByCanonicalName(std::string_view filePath,
       mi::neuraylib::ITransaction *transaction)
       -> const mi::neuraylib::IModule *;
 

--- a/src/hdanari/rd/CMakeLists.txt
+++ b/src/hdanari/rd/CMakeLists.txt
@@ -8,6 +8,7 @@ project_add_library(SHARED
   anariTokens.cpp
   debugCodes.cpp
   geometry.cpp
+  implicitSurfaceSceneIndexPlugin.cpp
   instancer.cpp
   light.cpp
   material.cpp

--- a/src/hdanari/rd/CMakeLists.txt
+++ b/src/hdanari/rd/CMakeLists.txt
@@ -23,6 +23,7 @@ project_add_library(SHARED
   points.cpp
   renderBuffer.cpp
   renderDelegate.cpp
+  rendererParameters.cpp
   rendererPlugin.cpp
   renderPass.cpp
   sampler.cpp

--- a/src/hdanari/rd/CMakeLists.txt
+++ b/src/hdanari/rd/CMakeLists.txt
@@ -23,6 +23,7 @@ project_add_library(SHARED
   points.cpp
   renderBuffer.cpp
   renderDelegate.cpp
+  renderSettings.cpp
   rendererParameters.cpp
   rendererPlugin.cpp
   renderPass.cpp

--- a/src/hdanari/rd/CMakeLists.txt
+++ b/src/hdanari/rd/CMakeLists.txt
@@ -26,6 +26,7 @@ project_add_library(SHARED
   rendererPlugin.cpp
   renderPass.cpp
   sampler.cpp
+  subdivision.cpp
 )
 # Visual Studio compiler might kill some symbols (arch_ctor_<name>) used to initialize USD plugins at load time.
 # Disabling that optimization for the renderPlugin file works around the issue.
@@ -42,7 +43,12 @@ if (MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE /Zc:preprocessor)
 endif()
 
+# OpenSubdiv (osdCPU) is used by subdivision.cpp for mesh refinement. USD
+# already depends on it, so it resolves to the same install.
+find_package(OpenSubdiv REQUIRED)
+
 project_link_libraries(PUBLIC anari::anari_static ${PXR_LIBRARIES})
+project_link_libraries(PRIVATE OpenSubdiv::osdCPU)
 if(HDANARI_ENABLE_MDL)
   project_sources(
     PRIVATE material/mdl.cpp

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -113,8 +113,7 @@ static bool _FlipVIfHolding(VtValue *value)
 
 static VtValue _FlipTextureCoordinateV(VtValue value)
 {
-  _FlipVIfHolding<VtVec2fArray>(&value)
-      || _FlipVIfHolding<VtVec3fArray>(&value)
+  _FlipVIfHolding<VtVec2fArray>(&value) || _FlipVIfHolding<VtVec3fArray>(&value)
       || _FlipVIfHolding<VtVec2dArray>(&value)
       || _FlipVIfHolding<VtVec2hArray>(&value);
   return value;
@@ -585,10 +584,12 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   // when its own bound data changed. Use the rprim's geometry dirty bits only:
   // instancer primvar dirtiness (transform, per-instance values) is bound on
   // the instance, not the geometry, and must not trigger a geometry rebuild.
-  const bool geometryDataDirty = (*dirtyBits
-      & (HdChangeTracker::DirtyPoints | HdChangeTracker::DirtyNormals
-          | HdChangeTracker::DirtyTopology | HdChangeTracker::DirtyPrimvar
-          | HdChangeTracker::DirtyDisplayStyle | HdChangeTracker::DirtyWidths))
+  const bool geometryDataDirty =
+      (*dirtyBits
+          & (HdChangeTracker::DirtyPoints | HdChangeTracker::DirtyNormals
+              | HdChangeTracker::DirtyTopology | HdChangeTracker::DirtyPrimvar
+              | HdChangeTracker::DirtyDisplayStyle
+              | HdChangeTracker::DirtyWidths))
       != 0;
 
   // Based on the above, gather needed primvars descriptors. To be used to
@@ -926,7 +927,8 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
       for (const auto &bindingPoint : geomSpecificRemovedBindings) {
         anari::unsetParameter(
             device_, geometryDesc.geometry, bindingPoint.GetText());
-      }      anari::commitParameters(device_, geometryDesc.geometry);
+      }
+      anari::commitParameters(device_, geometryDesc.geometry);
     } else {
       // Unchanged geometry: keep the existing anari object and carry the
       // geom-specific binding bookkeeping forward for the next sync's diff.
@@ -938,7 +940,8 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
     // actually changed. DirtyMaterialId is re-flagged every frame on Varying
     // prims; committing the surface unconditionally would reset the renderer's
     // accumulation each frame and prevent convergence.
-    if (geometryDesc.material != geomInfo.material) {      geometryDesc.material = geomInfo.material;
+    if (geometryDesc.material != geomInfo.material) {
+      geometryDesc.material = geomInfo.material;
       anari::setParameter(
           device_, geometryDesc.surface, "material", geomInfo.material);
       anari::commitParameters(device_, geometryDesc.surface);
@@ -966,7 +969,8 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
             "transform",
             GfMatrix4f(baseTransform));
         anari::setParameter(device_, geometryDesc.instance, "id", 0u);
-      }      anari::commitParameters(device_, geometryDesc.instance);
+      }
+      anari::commitParameters(device_, geometryDesc.instance);
     }
     instances.push_back(geometryDesc.instance);
   }

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -1047,8 +1047,11 @@ anari::Array1D HdAnariGeometry::_GetAttributeArray(
   const void *data = nullptr;
   size_t size = 0;
 
-  if (!value.IsEmpty() && _GetVtArrayBufferData(value, &data, &size, &type)
-      && size) {
+  if (!value.IsEmpty() && _GetVtArrayBufferData(value, &data, &size, &type)) {
+    // A recognized but empty primvar (e.g. an empty-points/normals placeholder
+    // mesh) yields no attribute -- that's benign, not an error.
+    if (size == 0)
+      return {};
     // Don't assume any ownership of the data. Map can copy asap.
     if (overrideType != ANARI_UNKNOWN)
       type = overrideType;
@@ -1059,7 +1062,8 @@ anari::Array1D HdAnariGeometry::_GetAttributeArray(
     return array;
   }
 
-  TF_RUNTIME_ERROR("Cannot extract value buffer from VtValue");
+  TF_RUNTIME_ERROR("Cannot extract value buffer from VtValue of type '%s'",
+      value.GetTypeName().c_str());
   return {};
 }
 

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -534,6 +534,18 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
     }
   }
 
+  // Re-uploading/committing a geometry makes the device rebuild it (recompute
+  // tangents, rebuild the BVH). Native-instanced prototypes are flagged Varying
+  // and re-Synced every frame with no real change, so only touch the geometry
+  // when its own bound data changed. Use the rprim's geometry dirty bits only:
+  // instancer primvar dirtiness (transform, per-instance values) is bound on
+  // the instance, not the geometry, and must not trigger a geometry rebuild.
+  const bool geometryDataDirty = (*dirtyBits
+      & (HdChangeTracker::DirtyPoints | HdChangeTracker::DirtyNormals
+          | HdChangeTracker::DirtyTopology | HdChangeTracker::DirtyPrimvar
+          | HdChangeTracker::DirtyDisplayStyle | HdChangeTracker::DirtyWidths))
+      != 0;
+
   // Based on the above, gather needed primvars descriptors. To be used to
   // create primvars sources.
   // Compute primvars have precedence over regular primvars.
@@ -736,6 +748,9 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   // anari objects.
   for (auto &&[subsetId, geomInfo] : geomSubsetInfos) {
     auto &geometryDesc = geomSubsetGeometry_[subsetId];
+    const bool firstTime = !geometryDesc.instance;
+    const bool materialChanged =
+        !firstTime && geometryDesc.material != geomInfo.material;
 
     PrimvarStateDesc removedState;
     PrimvarStateDesc updatedState;
@@ -754,6 +769,7 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
           device_, geometryDesc.surface, "id", uint32_t(GetPrimId()));
       anari::setParameter(
           device_, geometryDesc.surface, "material", geomInfo.material);
+      geometryDesc.material = geomInfo.material;
       anari::commitParameters(device_, geometryDesc.surface);
 
       geometryDesc.group = anari::newObject<anari::Group>(device_);
@@ -798,99 +814,111 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
       newPrimvarsBinding = mainGeomInfo.primvarBinding;
     }
 
-    // FIXME: Do the same with displayOpacity and maybe others...
-    if (displayColorIsAuthored) {
-      // Make sure any previous default display color is removed so the actual
-      // authored one is used.
-      if (std::binary_search(cbegin(updatedPrimvars),
-              cend(updatedPrimvars),
-              HdTokens->displayColor)) {
-        // Clear the constant value so any other can be used instead
-        if (auto it = previousPrimvarsBinding.find(HdTokens->displayColor);
-            it != cend(previousPrimvarsBinding)) {
-          anari::unsetParameter(
-              device_, geometryDesc.geometry, it->second.GetText());
+    if (firstTime || geometryDataDirty || materialChanged) {
+      // FIXME: Do the same with displayOpacity and maybe others...
+      if (displayColorIsAuthored) {
+        // Make sure any previous default display color is removed so the actual
+        // authored one is used.
+        if (std::binary_search(cbegin(updatedPrimvars),
+                cend(updatedPrimvars),
+                HdTokens->displayColor)) {
+          // Clear the constant value so any other can be used instead
+          if (auto it = previousPrimvarsBinding.find(HdTokens->displayColor);
+              it != cend(previousPrimvarsBinding)) {
+            anari::unsetParameter(
+                device_, geometryDesc.geometry, it->second.GetText());
+          }
+        }
+      } else {
+        // If the material depends on displayColor, make sure we handle the case
+        // it is not authored.
+        if (auto it = newPrimvarsBinding.find(HdTokens->displayColor);
+            it != cend(newPrimvarsBinding)) {
+          anari::setParameter(device_,
+              geometryDesc.geometry,
+              it->second.GetText(),
+              GfVec4f(0.8f, 0.8f, 0.8f, 1.0f));
         }
       }
-    } else {
-      // If the material depends on displayColor, make sure we handle the case
-      // it is not authored.
-      if (auto it = newPrimvarsBinding.find(HdTokens->displayColor);
-          it != cend(newPrimvarsBinding)) {
-        anari::setParameter(device_,
-            geometryDesc.geometry,
-            it->second.GetText(),
-            GfVec4f(0.8f, 0.8f, 0.8f, 1.0f));
-      }
-    }
-    // Apply the changes to the geometry object
-    SyncAnariGeometry(device_,
-        geometryDesc.geometry,
-        primvarSource_,
-        newPrimvarsBinding,
-        previousPrimvarsBinding,
-
-        updatedState,
-        removedState);
-
-    // We do try and get them at each sync, as it is not clear when those are
-    // dirtied. The expectation is that the implementation of
-    // GetGeomSpecificPrimvars is doing the caching.
-    auto geomSpecificBindingPoints = GetGeomSpecificPrimvars(sceneDelegate,
-        dirtyBits,
-        TfToken::Set(cbegin(allPrimvars), cend(allPrimvars)),
-        points,
-        subsetId);
-
-    for (auto &&[bindingPoint, array] : geomSpecificBindingPoints) {
-      geomSpecificPrimvarBindings[subsetId].push_back(bindingPoint);
-      anari::setParameter(
-          device_, geometryDesc.geometry, bindingPoint.GetText(), array);
-    }
-
-    // Clear geomspecfic binding points set by previous sync that are no more
-    // used.
-    std::vector<TfToken> geomSpecificRemovedBindings;
-    std::set_difference(cbegin(geomSpecificPrimvarBindings_[subsetId]),
-        cend(geomSpecificPrimvarBindings_[subsetId]),
-        cbegin(geomSpecificPrimvarBindings[subsetId]),
-        cend(geomSpecificPrimvarBindings[subsetId]),
-        back_inserter(geomSpecificRemovedBindings));
-
-    for (const auto &bindingPoint : geomSpecificRemovedBindings) {
-      anari::unsetParameter(
-          device_, geometryDesc.geometry, bindingPoint.GetText());
-    }
-
-    anari::commitParameters(device_, geometryDesc.geometry);
-
-    // Material update
-    if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-      anari::setParameter(
-          device_, geometryDesc.surface, "material", geomInfo.material);
-    }
-    anari::commitParameters(device_, geometryDesc.surface);
-
-    // Instance update
-    if (instancer) {
-      SyncAnariInstance(device_,
-          geometryDesc.instance,
+      // Apply the changes to the geometry object
+      SyncAnariGeometry(device_,
+          geometryDesc.geometry,
           primvarSource_,
           newPrimvarsBinding,
           previousPrimvarsBinding,
 
           updatedState,
           removedState);
+
+      // We do try and get them at each sync, as it is not clear when those are
+      // dirtied. The expectation is that the implementation of
+      // GetGeomSpecificPrimvars is doing the caching.
+      auto geomSpecificBindingPoints = GetGeomSpecificPrimvars(sceneDelegate,
+          dirtyBits,
+          TfToken::Set(cbegin(allPrimvars), cend(allPrimvars)),
+          points,
+          subsetId);
+
+      for (auto &&[bindingPoint, array] : geomSpecificBindingPoints) {
+        geomSpecificPrimvarBindings[subsetId].push_back(bindingPoint);
+        anari::setParameter(
+            device_, geometryDesc.geometry, bindingPoint.GetText(), array);
+      }
+
+      // Clear geomspecfic binding points set by previous sync that are no more
+      // used.
+      std::vector<TfToken> geomSpecificRemovedBindings;
+      std::set_difference(cbegin(geomSpecificPrimvarBindings_[subsetId]),
+          cend(geomSpecificPrimvarBindings_[subsetId]),
+          cbegin(geomSpecificPrimvarBindings[subsetId]),
+          cend(geomSpecificPrimvarBindings[subsetId]),
+          back_inserter(geomSpecificRemovedBindings));
+
+      for (const auto &bindingPoint : geomSpecificRemovedBindings) {
+        anari::unsetParameter(
+            device_, geometryDesc.geometry, bindingPoint.GetText());
+      }      anari::commitParameters(device_, geometryDesc.geometry);
     } else {
-      auto baseTransform = sceneDelegate->GetTransform(GetId());
-      anari::setParameter(device_,
-          geometryDesc.instance,
-          "transform",
-          GfMatrix4f(baseTransform));
-      anari::setParameter(device_, geometryDesc.instance, "id", 0u);
+      // Unchanged geometry: keep the existing anari object and carry the
+      // geom-specific binding bookkeeping forward for the next sync's diff.
+      geomSpecificPrimvarBindings[subsetId] =
+          geomSpecificPrimvarBindings_[subsetId];
     }
 
-    anari::commitParameters(device_, geometryDesc.instance);
+    // Material update: only re-commit the surface when the bound material
+    // actually changed. DirtyMaterialId is re-flagged every frame on Varying
+    // prims; committing the surface unconditionally would reset the renderer's
+    // accumulation each frame and prevent convergence.
+    if (geometryDesc.material != geomInfo.material) {      geometryDesc.material = geomInfo.material;
+      anari::setParameter(
+          device_, geometryDesc.surface, "material", geomInfo.material);
+      anari::commitParameters(device_, geometryDesc.surface);
+    }
+
+    // Instance update: only when the transform/instancing actually changed.
+    const bool instanceDirty = firstTime
+        || HdChangeTracker::IsTransformDirty(*dirtyBits, id)
+        || HdChangeTracker::IsInstancerDirty(*dirtyBits, id)
+        || HdChangeTracker::IsInstanceIndexDirty(*dirtyBits, id);
+    if (instanceDirty) {
+      if (instancer) {
+        SyncAnariInstance(device_,
+            geometryDesc.instance,
+            primvarSource_,
+            newPrimvarsBinding,
+            previousPrimvarsBinding,
+
+            updatedState,
+            removedState);
+      } else {
+        auto baseTransform = sceneDelegate->GetTransform(GetId());
+        anari::setParameter(device_,
+            geometryDesc.instance,
+            "transform",
+            GfMatrix4f(baseTransform));
+        anari::setParameter(device_, geometryDesc.instance, "id", 0u);
+      }      anari::commitParameters(device_, geometryDesc.instance);
+    }
     instances.push_back(geometryDesc.instance);
   }
 

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -88,14 +88,18 @@ static const std::array<TfToken, 6> kTextureCoordinatePrimvarNames = {
     TfToken("UVMap"),
     TfToken("map1")};
 
-static bool _IsTextureCoordinatePrimvar(const HdPrimvarDescriptor &pvd)
+static bool _IsTextureCoordinatePrimvarName(const TfToken &name)
 {
-  if (pvd.role == HdPrimvarRoleTokens->textureCoordinate)
-    return true;
   return std::find(begin(kTextureCoordinatePrimvarNames),
              end(kTextureCoordinatePrimvarNames),
-             pvd.name)
+             name)
       != end(kTextureCoordinatePrimvarNames);
+}
+
+static bool _IsTextureCoordinatePrimvar(const HdPrimvarDescriptor &pvd)
+{
+  return pvd.role == HdPrimvarRoleTokens->textureCoordinate
+      || _IsTextureCoordinatePrimvarName(pvd.name);
 }
 
 template <typename VEC_ARRAY_T>
@@ -117,6 +121,37 @@ static VtValue _FlipTextureCoordinateV(VtValue value)
       || _FlipVIfHolding<VtVec2dArray>(&value)
       || _FlipVIfHolding<VtVec2hArray>(&value);
   return value;
+}
+
+// The material backends bind their texture-coordinate input to the primvar
+// literally named `st` (the MDL/MaterialX default set, read as attribute0..N).
+// A mesh whose UVs are authored under another name (Blender `UVMap`, `map1`,
+// ...) would then deliver no texcoords. Re-key each texcoord binding whose
+// primvar is absent on the mesh to an unused mesh texture-coordinate primvar so
+// the data still reaches its attribute. `meshTexcoords` and `meshPrimvarsSorted`
+// are sorted; the latter enables a binary search for presence.
+static HdAnariMaterial::PrimvarBinding _ResolveTexcoordBinding(
+    const HdAnariMaterial::PrimvarBinding &binding,
+    const std::vector<TfToken> &meshTexcoords,
+    const std::vector<TfToken> &meshPrimvarsSorted)
+{
+  std::vector<TfToken> unclaimed;
+  for (const TfToken &tc : meshTexcoords)
+    if (binding.find(tc) == cend(binding))
+      unclaimed.push_back(tc);
+
+  HdAnariMaterial::PrimvarBinding resolved;
+  size_t next = 0;
+  for (const auto &[name, attribute] : binding) {
+    const bool onMesh = std::binary_search(
+        cbegin(meshPrimvarsSorted), cend(meshPrimvarsSorted), name);
+    if (!onMesh && _IsTextureCoordinatePrimvarName(name)
+        && next < unclaimed.size())
+      resolved.emplace(unclaimed[next++], attribute);
+    else
+      resolved.emplace(name, attribute);
+  }
+  return resolved;
 }
 
 bool HdAnariGeometry::_GetVtArrayBufferData(
@@ -431,16 +466,22 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
     }
   }
 
+  std::vector<TfToken> meshTexcoords;
   for (auto i = 0; i < HdInterpolationCount; ++i) {
     for (const auto &pv :
         sceneDelegate->GetPrimvarDescriptors(GetId(), HdInterpolation(i))) {
       allPrimvars.push_back(pv.name);
       if (pv.name == HdTokens->displayColor)
         displayColorIsAuthored = true;
+      if (_IsTextureCoordinatePrimvar(pv))
+        meshTexcoords.push_back(pv.name);
     }
   }
   // Make sure this is stored we can do binary searches and set differences.
   std::sort(begin(allPrimvars), end(allPrimvars));
+  std::sort(begin(meshTexcoords), end(meshTexcoords));
+  meshTexcoords.erase(
+      std::unique(begin(meshTexcoords), end(meshTexcoords)), end(meshTexcoords));
 
   // Get an exhaustive list of primvars used by the different materials
   // referenced this geometry and its subsets.
@@ -455,7 +496,8 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
       renderIndex.GetSprim(HdPrimTypeTokens->material, GetMaterialId()));
   if (auto mat = material ? material->GetAnariMaterial() : nullptr) {
     mainGeomInfo.material = material->GetAnariMaterial();
-    mainGeomInfo.primvarBinding = material->GetPrimvarBinding();
+    mainGeomInfo.primvarBinding = _ResolveTexcoordBinding(
+        material->GetPrimvarBinding(), meshTexcoords, allPrimvars);
   } else {
     mainGeomInfo.material = renderParam->GetDefaultMaterial();
     mainGeomInfo.primvarBinding = renderParam->GetDefaultPrimvarBinding();
@@ -484,7 +526,9 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
         renderIndex.GetSprim(HdPrimTypeTokens->material, subset.materialId));
     auto geomSubsetInfo = (material && material->GetAnariMaterial())
         ? GeomSubsetInfo{material->GetAnariMaterial(),
-              material->GetPrimvarBinding()}
+              _ResolveTexcoordBinding(material->GetPrimvarBinding(),
+                  meshTexcoords,
+                  allPrimvars)}
         : GeomSubsetInfo{renderParam->GetDefaultMaterial(),
               renderParam->GetDefaultPrimvarBinding()};
 

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -712,8 +712,9 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
 
   // Handle anari objects creation
   std::vector<anari::Instance> instances;
-  if (geomSubsetInfos.empty()) {
-    //  Use main geom is no subset is defined.
+  // Build the main geometry when no subset is defined, or when subsets leave
+  // some faces uncovered (those remaining faces use the prim's own material).
+  if (geomSubsetInfos.empty() || HasMainGeometry()) {
     geomSubsetInfos.insert({GetId(), mainGeomInfo});
   }
 

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -128,8 +128,9 @@ static VtValue _FlipTextureCoordinateV(VtValue value)
 // A mesh whose UVs are authored under another name (Blender `UVMap`, `map1`,
 // ...) would then deliver no texcoords. Re-key each texcoord binding whose
 // primvar is absent on the mesh to an unused mesh texture-coordinate primvar so
-// the data still reaches its attribute. `meshTexcoords` and `meshPrimvarsSorted`
-// are sorted; the latter enables a binary search for presence.
+// the data still reaches its attribute. `meshTexcoords` and
+// `meshPrimvarsSorted` are sorted; the latter enables a binary search for
+// presence.
 static HdAnariMaterial::PrimvarBinding _ResolveTexcoordBinding(
     const HdAnariMaterial::PrimvarBinding &binding,
     const std::vector<TfToken> &meshTexcoords,
@@ -480,8 +481,8 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   // Make sure this is stored we can do binary searches and set differences.
   std::sort(begin(allPrimvars), end(allPrimvars));
   std::sort(begin(meshTexcoords), end(meshTexcoords));
-  meshTexcoords.erase(
-      std::unique(begin(meshTexcoords), end(meshTexcoords)), end(meshTexcoords));
+  meshTexcoords.erase(std::unique(begin(meshTexcoords), end(meshTexcoords)),
+      end(meshTexcoords));
 
   // Get an exhaustive list of primvars used by the different materials
   // referenced this geometry and its subsets.
@@ -492,16 +493,26 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   // Main geometry first...
   GeomSubsetInfo mainGeomInfo;
 
+  // Resolve an anari material + primvar binding for a (possibly null) material
+  // prim. Falls back to the shared default whenever there is no material *or*
+  // the material resolved to the shared default (e.g. a network with no surface
+  // terminal): that default samples the "color" attribute, so it must always be
+  // paired with the default binding that makes the geometry expose it -- else
+  // the attribute is missing and the surface renders black.
+  auto resolveMaterialAndBinding =
+      [&](HdAnariMaterial *material) -> GeomSubsetInfo {
+    auto anariMat = material ? material->GetAnariMaterial() : nullptr;
+    if (!anariMat || anariMat == renderParam->GetDefaultMaterial())
+      return {renderParam->GetDefaultMaterial(),
+          renderParam->GetDefaultPrimvarBinding()};
+    return {anariMat,
+        _ResolveTexcoordBinding(
+            material->GetPrimvarBinding(), meshTexcoords, allPrimvars)};
+  };
+
   HdAnariMaterial *material = static_cast<HdAnariMaterial *>(
       renderIndex.GetSprim(HdPrimTypeTokens->material, GetMaterialId()));
-  if (auto mat = material ? material->GetAnariMaterial() : nullptr) {
-    mainGeomInfo.material = material->GetAnariMaterial();
-    mainGeomInfo.primvarBinding = _ResolveTexcoordBinding(
-        material->GetPrimvarBinding(), meshTexcoords, allPrimvars);
-  } else {
-    mainGeomInfo.material = renderParam->GetDefaultMaterial();
-    mainGeomInfo.primvarBinding = renderParam->GetDefaultPrimvarBinding();
-  }
+  mainGeomInfo = resolveMaterialAndBinding(material);
 
   // Points and normals are implicit bindings
   mainGeomInfo.primvarBinding.insert(
@@ -524,13 +535,7 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
   for (auto subset : GetGeomSubsets(sceneDelegate, dirtyBits)) {
     HdAnariMaterial *material = static_cast<HdAnariMaterial *>(
         renderIndex.GetSprim(HdPrimTypeTokens->material, subset.materialId));
-    auto geomSubsetInfo = (material && material->GetAnariMaterial())
-        ? GeomSubsetInfo{material->GetAnariMaterial(),
-              _ResolveTexcoordBinding(material->GetPrimvarBinding(),
-                  meshTexcoords,
-                  allPrimvars)}
-        : GeomSubsetInfo{renderParam->GetDefaultMaterial(),
-              renderParam->GetDefaultPrimvarBinding()};
+    auto geomSubsetInfo = resolveMaterialAndBinding(material);
 
     // Points and normals are implicit bindings
     geomSubsetInfo.primvarBinding.insert(

--- a/src/hdanari/rd/geometry.cpp
+++ b/src/hdanari/rd/geometry.cpp
@@ -75,6 +75,51 @@ static bool _GetVtArrayBufferData_T(
   return false;
 }
 
+// USD authors texture coordinates with v=0 at the bottom of the image; ANARI
+// samples arrays with element (0,0) at the top. HdAnari uploads texture arrays
+// top-origin, so the v axis of texture-coordinate primvars is flipped here to
+// reconcile the two conventions. Detection is by primvar role or the
+// conventional UV names only -- material-declared inputs are not consulted.
+static const std::array<TfToken, 6> kTextureCoordinatePrimvarNames = {
+    TfToken("st"),
+    TfToken("st0"),
+    TfToken("st1"),
+    TfToken("uv"),
+    TfToken("UVMap"),
+    TfToken("map1")};
+
+static bool _IsTextureCoordinatePrimvar(const HdPrimvarDescriptor &pvd)
+{
+  if (pvd.role == HdPrimvarRoleTokens->textureCoordinate)
+    return true;
+  return std::find(begin(kTextureCoordinatePrimvarNames),
+             end(kTextureCoordinatePrimvarNames),
+             pvd.name)
+      != end(kTextureCoordinatePrimvarNames);
+}
+
+template <typename VEC_ARRAY_T>
+static bool _FlipVIfHolding(VtValue *value)
+{
+  if (!value->IsHolding<VEC_ARRAY_T>())
+    return false;
+  VEC_ARRAY_T a = value->UncheckedGet<VEC_ARRAY_T>();
+  using Scalar = typename VEC_ARRAY_T::value_type::ScalarType;
+  for (auto &uv : a)
+    uv[1] = Scalar(1) - uv[1];
+  *value = VtValue(a);
+  return true;
+}
+
+static VtValue _FlipTextureCoordinateV(VtValue value)
+{
+  _FlipVIfHolding<VtVec2fArray>(&value)
+      || _FlipVIfHolding<VtVec3fArray>(&value)
+      || _FlipVIfHolding<VtVec2dArray>(&value)
+      || _FlipVIfHolding<VtVec2hArray>(&value);
+  return value;
+}
+
 bool HdAnariGeometry::_GetVtArrayBufferData(
     VtValue v, const void **data, size_t *size, anari::DataType *type)
 {
@@ -615,8 +660,11 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
 
       // FIXME: What if an instance prim is a computation primvar. This cannot
       // work with the actual implementation of GatherInstancePrimvar.
+      VtValue value = valueIt->second;
+      if (_IsTextureCoordinatePrimvar(pvd))
+        value = _FlipTextureCoordinateV(std::move(value));
       auto source = UpdatePrimvarSource(
-          sceneDelegate, pvd.interpolation, pvd.name, valueIt->second);
+          sceneDelegate, pvd.interpolation, pvd.name, value);
 
       // The spot should always be free as it was removed if needed when
       // processing primvar removal.
@@ -628,10 +676,11 @@ void HdAnariGeometry::Sync(HdSceneDelegate *sceneDelegate,
       if (primvarSource_.count(pvd.name) != 0) {
         continue;
       }
-      auto source = UpdatePrimvarSource(sceneDelegate,
-          pvd.interpolation,
-          pvd.name,
-          sceneDelegate->Get(id, pvd.name));
+      VtValue value = sceneDelegate->Get(id, pvd.name);
+      if (_IsTextureCoordinatePrimvar(pvd))
+        value = _FlipTextureCoordinateV(std::move(value));
+      auto source = UpdatePrimvarSource(
+          sceneDelegate, pvd.interpolation, pvd.name, value);
 
       primvarSource_.insert({pvd.name, source});
       primvarInterpolation.insert({pvd.name, pvd.interpolation});

--- a/src/hdanari/rd/geometry.h
+++ b/src/hdanari/rd/geometry.h
@@ -120,6 +120,14 @@ class HdAnariGeometry : public HdMesh
     return {};
   }
 
+  // Whether a "main" geometry (the prim's own material) should be built in
+  // addition to any geomsubsets. True unless a subset partition covers every
+  // face, in which case there is nothing left for the main material.
+  virtual bool HasMainGeometry() const
+  {
+    return true;
+  }
+
  private:
   // Data //
   bool _populated{false};

--- a/src/hdanari/rd/geometry.h
+++ b/src/hdanari/rd/geometry.h
@@ -170,6 +170,8 @@ class HdAnariGeometry : public HdMesh
     anari::Surface surface{};
     anari::Group group{};
     anari::Instance instance{};
+    // Last material bound to the surface, so we only re-commit it on change.
+    anari::Material material{};
   };
 
   using GeomSubsetToAnariInstanceDesc =

--- a/src/hdanari/rd/implicitSurfaceSceneIndexPlugin.cpp
+++ b/src/hdanari/rd/implicitSurfaceSceneIndexPlugin.cpp
@@ -1,0 +1,66 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "implicitSurfaceSceneIndexPlugin.h"
+
+#include <pxr/imaging/hd/retainedDataSource.h>
+#include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hdsi/implicitSurfaceSceneIndex.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    ((sceneIndexPluginName, "HdAnari_ImplicitSurfaceSceneIndexPlugin")));
+
+// Must match the renderer plugin displayName in plugInfo.json.in.
+static const char *const _pluginDisplayName = "Anari";
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+  HdSceneIndexPluginRegistry::Define<HdAnari_ImplicitSurfaceSceneIndexPlugin>();
+}
+
+TF_REGISTRY_FUNCTION(HdSceneIndexPlugin)
+{
+  const HdSceneIndexPluginRegistry::InsertionPhase insertionPhase = 0;
+
+  HdSceneIndexPluginRegistry::GetInstance().RegisterSceneIndexForRenderer(
+      _pluginDisplayName,
+      _tokens->sceneIndexPluginName,
+      /* inputArgs = */ nullptr,
+      insertionPhase,
+      HdSceneIndexPluginRegistry::InsertionOrderAtStart);
+}
+
+HdAnari_ImplicitSurfaceSceneIndexPlugin::
+    HdAnari_ImplicitSurfaceSceneIndexPlugin() = default;
+
+HdSceneIndexBaseRefPtr
+HdAnari_ImplicitSurfaceSceneIndexPlugin::_AppendSceneIndex(
+    const HdSceneIndexBaseRefPtr &inputScene,
+    const HdContainerDataSourceHandle &inputArgs)
+{
+  // HdAnari has no native implicit geometry, so emit meshes for every type.
+  HdDataSourceBaseHandle const toMeshSrc =
+      HdRetainedTypedSampledDataSource<TfToken>::New(
+          HdsiImplicitSurfaceSceneIndexTokens->toMesh);
+
+  HdContainerDataSourceHandle const localInputArgs =
+      HdRetainedContainerDataSource::New(HdPrimTypeTokens->sphere,
+          toMeshSrc,
+          HdPrimTypeTokens->cube,
+          toMeshSrc,
+          HdPrimTypeTokens->cone,
+          toMeshSrc,
+          HdPrimTypeTokens->cylinder,
+          toMeshSrc,
+          HdPrimTypeTokens->capsule,
+          toMeshSrc,
+          HdPrimTypeTokens->plane,
+          toMeshSrc);
+
+  return HdsiImplicitSurfaceSceneIndex::New(inputScene, localInputArgs);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/implicitSurfaceSceneIndexPlugin.h
+++ b/src/hdanari/rd/implicitSurfaceSceneIndexPlugin.h
@@ -1,0 +1,29 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef HDANARI_IMPLICIT_SURFACE_SCENE_INDEX_PLUGIN_H
+#define HDANARI_IMPLICIT_SURFACE_SCENE_INDEX_PLUGIN_H
+
+#include <pxr/imaging/hd/sceneIndexPlugin.h>
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// Scene index plugin that turns USD implicit surfaces (sphere, cube, cone,
+/// cylinder, capsule, plane) into meshes. HdAnari only supports the `mesh` and
+/// `points` rprim types, so without this conversion implicit prims are silently
+/// dropped by the render index.
+class HdAnari_ImplicitSurfaceSceneIndexPlugin : public HdSceneIndexPlugin
+{
+ public:
+  HdAnari_ImplicitSurfaceSceneIndexPlugin();
+
+ protected:
+  HdSceneIndexBaseRefPtr _AppendSceneIndex(
+      const HdSceneIndexBaseRefPtr &inputScene,
+      const HdContainerDataSourceHandle &inputArgs) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDANARI_IMPLICIT_SURFACE_SCENE_INDEX_PLUGIN_H

--- a/src/hdanari/rd/light.cpp
+++ b/src/hdanari/rd/light.cpp
@@ -135,10 +135,6 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
 
         anari::setAndReleaseParameter(
             device_, light_, "intensityDistribution", array);
-      } else {
-        TF_RUNTIME_ERROR("Failed to open texture file `%s` for `%s`, ignoring",
-            textureFile.GetResolvedPath().c_str(),
-            GetId().GetText());
       }
     } else if (lightType_ == HdPrimTypeTokens->diskLight) {
       float radius =
@@ -175,13 +171,15 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
               ANARI_FLOAT32_VEC3);
           anari::setAndReleaseParameter(device_, light_, "radiance", array);
         } else {
-          TF_RUNTIME_ERROR(
-              "Failed to open texture file `%s` for `%s`, ignoring",
-              textureFilePath.GetResolvedPath().c_str(),
+          // No resolvable HDRI: keep the uniform radiance set at construction
+          // so the dome acts as a constant environment instead of aborting.
+          TF_WARN("No usable texture for dome light `%s`; "
+                  "falling back to uniform radiance",
               GetId().GetText());
         }
       } else {
-        TF_RUNTIME_ERROR("Unsupported hdri texture format `%s` for `%s`",
+        TF_WARN("Unsupported hdri texture format `%s` for `%s`; "
+                "falling back to uniform radiance",
             textureFormatTk.GetText(),
             GetId().GetText());
       }
@@ -197,10 +195,6 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
 
         anari::setAndReleaseParameter(
             device_, light_, "intensityDistribution", array);
-      } else {
-        TF_RUNTIME_ERROR("Failed to open texture file `%s` for `%s`, ignoring",
-            textureFile.GetResolvedPath().c_str(),
-            GetId().GetText());
       }
     }
     anari::commitParameters(device_, light_);

--- a/src/hdanari/rd/light.cpp
+++ b/src/hdanari/rd/light.cpp
@@ -15,9 +15,13 @@
 
 #include <anari/anari_cpp.hpp>
 
+#include <cmath>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
 
 // Stage up axis used to align a dome light whose poleAxis is "scene".
 TfToken ResolveDomePoleAxis(HdSceneDelegate *sceneDelegate, const SdfPath &id)
@@ -114,6 +118,15 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
     float intensity =
         sceneDelegate->GetLightParamValue(id, HdLightTokens->intensity)
             .GetWithDefault<float>(1.0f);
+    float exposure =
+        sceneDelegate->GetLightParamValue(id, HdLightTokens->exposure)
+            .GetWithDefault<float>(0.0f);
+    // UsdLux folds exposure into intensity as a power-of-two stop scale.
+    float scaledIntensity = intensity * std::exp2(exposure);
+    auto color = sceneDelegate->GetLightParamValue(id, HdLightTokens->color)
+                     .GetWithDefault<GfVec3f>(GfVec3f(1.0f));
+    // When set, UsdLux area lights hold total emitted power constant by
+    // dividing the authored radiance by the emitter area.
     bool normalize =
         sceneDelegate->GetLightParamValue(id, HdLightTokens->normalize)
             .GetWithDefault<bool>(false);
@@ -121,14 +134,27 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
     if (lightType_ == HdPrimTypeTokens->sphereLight) {
       float radius =
           sceneDelegate->GetLightParamValue(id, HdLightTokens->radius)
-              .GetWithDefault<float>(0.0f);
+              .GetWithDefault<float>(0.5f);
       anari::setParameter(device_, light_, "radius", radius);
+      // Authored emission was previously dropped; the ANARI point light stayed
+      // at its default. Map UsdLux intensity to radiant intensity (W/sr).
+      // normalize holds total power constant by dividing by the emitter surface
+      // area (4*pi*r^2), matching the rect/disk lights.
+      float area = 4.0f * kPi * radius * radius;
+      float intensity =
+          (normalize && area > 0.0f) ? scaledIntensity / area : scaledIntensity;
+      anari::setParameter(device_, light_, "color", color);
+      anari::setParameter(device_, light_, "intensity", intensity);
     } else if (lightType_ == HdPrimTypeTokens->distantLight) {
       anari::setParameter(
           device_, light_, "direction", GfVec3f(0.0f, 0.0f, -1.0f));
       float angle = sceneDelegate->GetLightParamValue(id, HdLightTokens->angle)
                         .GetWithDefault<float>(0.53f);
       anari::setParameter(device_, light_, "angularDiameter", angle);
+      // Authored intensity/exposure/color were previously dropped, leaving the
+      // ANARI directional light at its default irradiance of 1 W/m^2.
+      anari::setParameter(device_, light_, "color", color);
+      anari::setParameter(device_, light_, "irradiance", scaledIntensity);
     } else if (lightType_ == HdPrimTypeTokens->domeLight) {
       // ANARI hdri up/direction are world-space directions the device rotates
       // by the instance transform, so they hold the latlong frame relative to
@@ -145,23 +171,31 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
           "up",
           GfVec3f(poleAlign.TransformDir(GfVec3d(0.0, 1.0, 0.0))));
 
-      auto intensity =
-          sceneDelegate->GetLightParamValue(id, HdLightTokens->intensity)
-              .GetWithDefault<float>(1.0f);
-      anari::setParameter(device_, light_, "scale", intensity);
+      anari::setParameter(device_, light_, "color", color);
+      anari::setParameter(device_, light_, "scale", scaledIntensity);
     } else if (lightType_ == HdPrimTypeTokens->rectLight) {
       auto width = sceneDelegate->GetLightParamValue(id, HdLightTokens->width)
                        .GetWithDefault<float>(1.0f);
       auto height = sceneDelegate->GetLightParamValue(id, HdLightTokens->height)
                         .GetWithDefault<float>(1.0f);
-      auto edge1 = GfVec3f(width / 2.0f, 0.0f, 0.0f);
-      auto edge2 = GfVec3f(0.0f, height / 2.0f, 0.0f);
+      // edge1 x edge2 is the emitting normal; order the full-width edges so it
+      // points along local -Z to match UsdLux rect emission.
+      auto edge1 = GfVec3f(width, 0.0f, 0.0f);
+      auto edge2 = GfVec3f(0.0f, -height, 0.0f);
       anari::setParameter(device_,
           light_,
           "position",
-          GfVec3f(-width / 2.0f, -height / 2.0f, 0.0f));
+          GfVec3f(-width / 2.0f, height / 2.0f, 0.0f));
       anari::setParameter(device_, light_, "edge1", edge1);
       anari::setParameter(device_, light_, "edge2", edge2);
+      // UsdLux rect intensity is emitted radiance; normalize divides it by the
+      // emitter area so total power is size-independent. The ANARI quad light's
+      // emitted radiance is carried by "intensity" (VisRTX ignores "radiance").
+      float area = width * height;
+      float radiance =
+          (normalize && area > 0.0f) ? scaledIntensity / area : scaledIntensity;
+      anari::setParameter(device_, light_, "color", color);
+      anari::setParameter(device_, light_, "intensity", radiance);
 
       auto textureFile =
           sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile)
@@ -178,8 +212,15 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
     } else if (lightType_ == HdPrimTypeTokens->diskLight) {
       float radius =
           sceneDelegate->GetLightParamValue(id, HdLightTokens->radius)
-              .GetWithDefault<float>(0.0f);
+              .GetWithDefault<float>(0.5f);
       anari::setParameter(device_, light_, "outerRadius", radius);
+      // The ANARI ring light takes radiant intensity, not radiance. For a
+      // Lambertian disk the on-axis radiant intensity is radiance * area.
+      float area = kPi * radius * radius;
+      float radiance =
+          (normalize && area > 0.0f) ? scaledIntensity / area : scaledIntensity;
+      anari::setParameter(device_, light_, "color", color);
+      anari::setParameter(device_, light_, "intensity", radiance * area);
     }
     anari::commitParameters(device_, light_);
   }

--- a/src/hdanari/rd/light.cpp
+++ b/src/hdanari/rd/light.cpp
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "light.h"
+#include "renderDelegate.h"
 #include "renderParam.h"
 
+#include <pxr/base/gf/rotation.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/imaging/hd/light.h>
 #include <pxr/imaging/hd/tokens.h>
@@ -14,6 +16,43 @@
 #include <anari/anari_cpp.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// Stage up axis used to align a dome light whose poleAxis is "scene".
+TfToken ResolveDomePoleAxis(HdSceneDelegate *sceneDelegate, const SdfPath &id)
+{
+  auto poleAxis = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->poleAxis)
+                      .GetWithDefault<TfToken>(UsdLuxTokens->scene);
+  if (poleAxis != UsdLuxTokens->scene)
+    return poleAxis;
+
+  auto *renderDelegate = sceneDelegate->GetRenderIndex().GetRenderDelegate();
+  auto upAxis =
+      renderDelegate->GetRenderSetting(HdAnariRenderSettingsTokens->upAxis);
+  if (upAxis.IsHolding<TfToken>())
+    return upAxis.UncheckedGet<TfToken>();
+  if (upAxis.IsHolding<std::string>())
+    return TfToken(upAxis.UncheckedGet<std::string>());
+  return TfToken("Y");
+}
+
+// Rotation aligning the canonical Y-up latlong frame (pole +Y, center +Z, per
+// the OpenEXR convention USD adopts) with the requested stage up axis. Applied
+// to the hdri up/direction vectors so the instance transform stays the
+// authored UsdGeomXformable alone.
+GfMatrix4d DomePoleAlignment(const TfToken &poleAxis)
+{
+  if (poleAxis == TfToken("Z")) {
+    // +90 about X: pole +Y->+Z, center +Z->-Y.
+    return GfMatrix4d(1.0).SetRotate(GfRotation(GfVec3d::XAxis(), 90.0));
+  }
+  if (poleAxis != TfToken("Y"))
+    TF_WARN("Unsupported dome pole axis '%s'; assuming Y.", poleAxis.GetText());
+  return GfMatrix4d(1.0);
+}
+
+} // namespace
 
 HdAnariLight::HdAnariLight(
     anari::Device device, SdfPath const &id, TfToken const &lightType)
@@ -57,13 +96,21 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
   if (id.IsEmpty())
     return;
 
-  if (HdLight::DirtyTransform && *dirtyBits) {
-    auto transform = sceneDelegate->GetTransform(id);
-    anari::setParameter(device_, instance_, "transform", GfMatrix4f(transform));
+  const bool transformDirty = *dirtyBits & HdLight::DirtyTransform;
+  const bool paramsDirty = *dirtyBits & HdLight::DirtyParams;
+  const bool resourceDirty = *dirtyBits & HdLight::DirtyResource;
+
+  // The instance carries only the authored UsdGeomXformable. A dome light's
+  // pole-axis alignment is folded into its up/direction vectors below.
+  if (transformDirty) {
+    anari::setParameter(device_,
+        instance_,
+        "transform",
+        GfMatrix4f(sceneDelegate->GetTransform(id)));
     anari::commitParameters(device_, instance_);
   }
 
-  if (HdLight::DirtyParams && *dirtyBits) {
+  if (paramsDirty) {
     float intensity =
         sceneDelegate->GetLightParamValue(id, HdLightTokens->intensity)
             .GetWithDefault<float>(1.0f);
@@ -83,28 +130,20 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
                         .GetWithDefault<float>(0.53f);
       anari::setParameter(device_, light_, "angularDiameter", angle);
     } else if (lightType_ == HdPrimTypeTokens->domeLight) {
-      auto poleAxis =
-          sceneDelegate->GetLightParamValue(id, UsdLuxTokens->poleAxis)
-              .GetWithDefault<TfToken>(UsdLuxTokens->scene);
-      if (poleAxis == UsdLuxTokens->scene) {
-        // Assume default Y up. Might be false if the scene up axis was changed.
-        poleAxis = TfToken("Y");
-      }
-
-      if (poleAxis == TfToken("Y")) {
-        anari::setParameter(
-            device_, light_, "direction", GfVec3f(0.0f, 0.0f, 1.0f));
-        anari::setParameter(device_, light_, "up", GfVec3f(0.0f, 1.0f, 0.0f));
-      } else if (poleAxis == TfToken("Z")) {
-        anari::setParameter(
-            device_, light_, "direction", GfVec3f(1.0f, 0.0f, 0.0f));
-        anari::setParameter(device_, light_, "up", GfVec3f(0.0f, 0.0f, 1.0f));
-      } else {
-        TF_RUNTIME_ERROR("Unknown up axis %s for %s. Assuming Y.",
-            poleAxis.GetText(),
-            GetId().GetText());
-        anari::setParameter(device_, light_, "direction", GfVec3f(0, 0, -1));
-      }
+      // ANARI hdri up/direction are world-space directions the device rotates
+      // by the instance transform, so they hold the latlong frame relative to
+      // the authored xform. Align the canonical USD frame (pole +Y, center +Z)
+      // to the stage up axis here; the instance carries only the xform.
+      auto poleAlign =
+          DomePoleAlignment(ResolveDomePoleAxis(sceneDelegate, id));
+      anari::setParameter(device_,
+          light_,
+          "direction",
+          GfVec3f(poleAlign.TransformDir(GfVec3d(0.0, 0.0, 1.0))));
+      anari::setParameter(device_,
+          light_,
+          "up",
+          GfVec3f(poleAlign.TransformDir(GfVec3d(0.0, 1.0, 0.0))));
 
       auto intensity =
           sceneDelegate->GetLightParamValue(id, HdLightTokens->intensity)
@@ -145,7 +184,7 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
     anari::commitParameters(device_, light_);
   }
 
-  if (HdLight::DirtyResource && *dirtyBits) {
+  if (resourceDirty) {
     if (lightType_ == HdPrimTypeTokens->domeLight) {
       auto textureFormat =
           sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFormat);
@@ -168,18 +207,21 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
               textureFilePath.GetResolvedPath(),
               HdAnariTextureLoader::MinMagFilter::Linear,
               HdAnariTextureLoader::ColorSpace::Raw,
-              ANARI_FLOAT32_VEC3);
+              ANARI_FLOAT32_VEC3,
+              /*flipVertical=*/true);
           anari::setAndReleaseParameter(device_, light_, "radiance", array);
         } else {
           // No resolvable HDRI: keep the uniform radiance set at construction
           // so the dome acts as a constant environment instead of aborting.
-          TF_WARN("No usable texture for dome light `%s`; "
-                  "falling back to uniform radiance",
+          TF_WARN(
+              "No usable texture for dome light `%s`; "
+              "falling back to uniform radiance",
               GetId().GetText());
         }
       } else {
-        TF_WARN("Unsupported hdri texture format `%s` for `%s`; "
-                "falling back to uniform radiance",
+        TF_WARN(
+            "Unsupported hdri texture format `%s` for `%s`; "
+            "falling back to uniform radiance",
             textureFormatTk.GetText(),
             GetId().GetText());
       }
@@ -200,13 +242,17 @@ void HdAnariLight::Sync(HdSceneDelegate *sceneDelegate,
     anari::commitParameters(device_, light_);
   }
 
+  auto rp = static_cast<HdAnariRenderParam *>(renderParam);
   if (!registered_) {
-    auto rp = static_cast<HdAnariRenderParam *>(renderParam);
     rp->RegisterLight(this);
-    rp->MarkNewSceneVersion();
-
     registered_ = true;
   }
+
+  // Any edit -- including an upAxis-driven re-orient the render pass pushes via
+  // DirtyParams -- must publish a new scene version, or the render pass won't
+  // re-commit the world and the device keeps the stale, converged frame.
+  if (transformDirty || paramsDirty || resourceDirty)
+    rp->MarkNewSceneVersion();
 
   *dirtyBits = HdLight::Clean;
 }

--- a/src/hdanari/rd/light.h
+++ b/src/hdanari/rd/light.h
@@ -26,6 +26,7 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     anari::Instance GetAnariLightInstance() const { return instance_; }
+    const TfToken &GetLightType() const { return lightType_; }
 
     void Finalize(HdRenderParam *renderParam) override;
 

--- a/src/hdanari/rd/material.cpp
+++ b/src/hdanari/rd/material.cpp
@@ -108,7 +108,7 @@ HdAnariMaterial::~HdAnariMaterial()
 {
   ReleaseSamplers(device_, samplers_);
   samplers_.clear();
-  if (material_)
+  if (material_ && ownsMaterial_)
     anari::release(device_, material_);
 }
 
@@ -121,6 +121,14 @@ void HdAnariMaterial::ReleaseSamplers(
 
 void HdAnariMaterial::Finalize(HdRenderParam *renderParam)
 {
+  // Drop our reference into the shared MDL material cache (the cache, not this
+  // prim, owns the anari material).
+  if (!mdlCacheKey_.empty()) {
+    static_cast<HdAnariRenderParam *>(renderParam)
+        ->ReleaseMdlMaterial(mdlCacheKey_);
+    mdlCacheKey_.clear();
+    material_ = nullptr;
+  }
   HdMaterial::Finalize(renderParam);
 }
 
@@ -144,6 +152,17 @@ void HdAnariMaterial::Sync(HdSceneDelegate *sceneDelegate,
       changeTracker.MarkAllRprimsDirty(HdChangeTracker::DirtyMaterialId);
     }
 
+    // Release the material we previously held before rebuilding it: either one
+    // we created, or a reference into the shared MDL material cache.
+    if (!mdlCacheKey_.empty()) {
+      hdAnariRenderParam->ReleaseMdlMaterial(mdlCacheKey_);
+      mdlCacheKey_.clear();
+    } else if (material_ && ownsMaterial_) {
+      anari::release(device_, material_);
+    }
+    material_ = nullptr;
+    ownsMaterial_ = false;
+
     //  Find material network and store it as HdMaterialNetwork2 for later use.
     VtValue networkMapResource = sceneDelegate->GetMaterialResource(GetId());
     HdMaterialNetworkMap networkMap =
@@ -153,18 +172,22 @@ void HdAnariMaterial::Sync(HdSceneDelegate *sceneDelegate,
     auto materialNetworkIface =
         HdMaterialNetwork2Interface(GetId(), &materialNetwork2_);
 
-    auto surfaceTerminalConnection = materialNetworkIface.GetTerminalConnection(HdMaterialTerminalTokens->surface);
+    auto surfaceTerminalConnection = materialNetworkIface.GetTerminalConnection(
+        HdMaterialTerminalTokens->surface);
     if (!surfaceTerminalConnection.first) {
-      TF_CODING_ERROR("Cannot find a surface terminal on prim %s",
-          materialNetworkIface.GetMaterialPrimPath().GetText());
+      // A material network with no surface terminal is valid (e.g. physics-only
+      // materials); fall back to the shared default without taking ownership.
       material_ = hdAnariRenderParam->GetDefaultMaterial();
       primvars_.clear();
       textures_.clear();
+      *dirtyBits = HdChangeTracker::Clean;
       return;
     }
 
-    // Try and guess the appropriate implementation for the surface terminal type
-    auto terminalType = materialNetworkIface.GetNodeType(surfaceTerminalConnection.second.upstreamNodeName);
+    // Try and guess the appropriate implementation for the surface terminal
+    // type
+    auto terminalType = materialNetworkIface.GetNodeType(
+        surfaceTerminalConnection.second.upstreamNodeName);
     // Assume Matte is a safe fallback.
     materialType_ = MaterialType::Matte;
 #ifdef HDANARI_ENABLE_MDL
@@ -172,7 +195,7 @@ void HdAnariMaterial::Sync(HdSceneDelegate *sceneDelegate,
       materialType_ = MaterialType::Mdl;
     } else
 #endif
-    if (terminalType == HdAnariMaterialTokens->UsdPreviewSurface) {
+        if (terminalType == HdAnariMaterialTokens->UsdPreviewSurface) {
       materialType_ = hdAnariRenderParam->GetMaterialType();
     }
 
@@ -199,8 +222,8 @@ void HdAnariMaterial::Sync(HdSceneDelegate *sceneDelegate,
     }
 #ifdef HDANARI_ENABLE_MDL
     case MaterialType::Mdl: {
-      material_ =
-          HdAnariMdlMaterial::CreateMaterial(device_, materialNetworkIface);
+      // The anari material is created/shared via the render param cache in the
+      // DirtyParams pass (it needs the resolved parameters to key on).
       primvars_ = HdAnariMdlMaterial::EnumeratePrimvars(
           materialNetworkIface, HdMaterialTerminalTokens->surface);
       textures_ = HdAnariMdlMaterial::EnumerateTextures(
@@ -210,12 +233,22 @@ void HdAnariMaterial::Sync(HdSceneDelegate *sceneDelegate,
 #endif
     }
 
+    // Matte / physically based materials are created and owned here. MDL
+    // materials are shared through the render param cache, not owned per prim.
+    ownsMaterial_ = (materialType_ != MaterialType::Mdl);
+
     // Build primvar mapping so we can load the texture and configure the
     // related samplers
     attributes_ = BuildPrimvarBinding(primvars_);
   }
 
-  if (*dirtyBits & HdMaterial::DirtyParams) {
+  // MDL materials are (re)acquired from the shared cache here. A DirtyResource
+  // sync that arrives without DirtyParams has just cleared material_, so force
+  // this pass in that case too — otherwise the material stays null until the
+  // next params-dirty sync.
+  const bool needsMdlAcquire =
+      materialType_ == MaterialType::Mdl && material_ == nullptr;
+  if ((*dirtyBits & HdMaterial::DirtyParams) || needsMdlAcquire) {
     auto materialNetworkIface =
         HdMaterialNetwork2Interface(GetId(), &materialNetwork2_);
 
@@ -246,22 +279,42 @@ void HdAnariMaterial::Sync(HdSceneDelegate *sceneDelegate,
     }
 #ifdef HDANARI_ENABLE_MDL
     case MaterialType::Mdl: {
-      HdAnariMdlMaterial::SyncMaterialParameters(device_,
-          material_,
-          materialNetworkIface,
-          attributes_,
-          primvars_,
-          samplers_);
+      // Share one anari material across instances with identical content so the
+      // device compiles it and loads its textures only once.
+      auto key = HdAnariMdlMaterial::ComputeContentKey(materialNetworkIface);
+      if (key != mdlCacheKey_) {
+        if (!mdlCacheKey_.empty())
+          hdAnariRenderParam->ReleaseMdlMaterial(mdlCacheKey_);
+        material_ = hdAnariRenderParam->AcquireMdlMaterial(key, [&]() {
+          auto m =
+              HdAnariMdlMaterial::CreateMaterial(device_, materialNetworkIface);
+          HdAnariMdlMaterial::SyncMaterialParameters(device_,
+              m,
+              materialNetworkIface,
+              attributes_,
+              primvars_,
+              samplers_);
+          anari::commitParameters(device_, m);
+          return m;
+        });
+        mdlCacheKey_ = key;
+      }
       break;
     }
 #endif
     }
   }
 
-  if (*dirtyBits && material_)
+  // Commit the materials we own (matte / physically based). Shared MDL
+  // materials are committed once when created in the cache; re-committing them
+  // per instance would recompile and reset the renderer's accumulation.
+  if ((*dirtyBits & (HdMaterial::DirtyResource | HdMaterial::DirtyParams))
+      && material_ && ownsMaterial_)
     anari::commitParameters(device_, material_);
 
-  *dirtyBits &= ~DirtyBits::AllDirty;
+  // Clear every bit we were given, not just AllDirty: otherwise unhandled bits
+  // stay set and Hydra re-Syncs this material on every frame.
+  *dirtyBits = HdChangeTracker::Clean;
 }
 
 std::map<SdfPath, anari::Sampler> HdAnariMaterial::CreateSamplers(

--- a/src/hdanari/rd/material.h
+++ b/src/hdanari/rd/material.h
@@ -76,6 +76,13 @@ struct HdAnariMaterial : public HdMaterial
 
   anari::Device device_{};
   anari::Material material_{};
+  // material_ may point at the render param's shared default material (when the
+  // network has no usable surface terminal) or at a cache-shared MDL material.
+  // Only release material_ when we actually created it (ownsMaterial_).
+  bool ownsMaterial_{false};
+  // Non-empty when material_ is a reference into the render param's shared MDL
+  // material cache; released through the cache, not directly.
+  std::string mdlCacheKey_{};
 
   MaterialType materialType_{MaterialType::Matte};
 

--- a/src/hdanari/rd/material/mdl.cpp
+++ b/src/hdanari/rd/material/mdl.cpp
@@ -28,11 +28,14 @@
 
 #include <anari/anari_cpp.hpp>
 
+#include <algorithm>
 #include <cctype>
 #include <cstdio>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -43,6 +46,59 @@ anari::Material HdAnariMdlMaterial::CreateMaterial(anari::Device device,
     const HdMaterialNetwork2Interface &materialNetworkIface)
 {
   return anari::newObject<anari::Material>(device, "mdl");
+}
+
+std::string HdAnariMdlMaterial::ComputeContentKey(
+    const HdMaterialNetwork2Interface &materialNetworkIface)
+{
+  auto con = materialNetworkIface.GetTerminalConnection(
+      HdMaterialTerminalTokens->surface);
+  if (!con.first)
+    return {};
+
+  auto terminal = con.second.upstreamNodeName;
+  std::ostringstream key;
+  key << materialNetworkIface.GetNodeType(terminal).GetString();
+
+  // Path-independent: the MDL material identifier plus the authored parameter
+  // values (same set ProcessMdlNode forwards to the device). Sorted so the key
+  // doesn't depend on enumeration order.
+  std::vector<std::string> params;
+  for (auto name :
+      materialNetworkIface.GetAuthoredNodeParameterNames(terminal)) {
+    if (name.GetString().substr(0, 9) == "typeName:")
+      continue;
+
+    auto nodeName = terminal;
+    auto inputName = name;
+    auto cnxs = materialNetworkIface.GetNodeInputConnection(terminal, name);
+    if (cnxs.size()) {
+      nodeName = cnxs.front().upstreamNodeName;
+      inputName = cnxs.front().upstreamOutputName;
+    }
+
+    auto value =
+        materialNetworkIface.GetNodeParameterValue(nodeName, inputName);
+    std::ostringstream entry;
+    entry << name.GetString() << '=';
+    // Key on the resolved asset path, the same value ProcessMdlNode forwards to
+    // the device. Two prims sharing an unresolved path but resolving to
+    // different files must not collide onto one shared material.
+    if (value.IsHolding<SdfAssetPath>()) {
+      auto ap = value.UncheckedGet<SdfAssetPath>();
+      auto path = ap.GetResolvedPath();
+      if (path.empty())
+        path = ap.GetAssetPath();
+      entry << path;
+    } else {
+      entry << value;
+    }
+    params.push_back(entry.str());
+  }
+  std::sort(begin(params), end(params));
+  for (const auto &p : params)
+    key << '|' << p;
+  return key.str();
 }
 
 void HdAnariMdlMaterial::SyncMaterialParameters(anari::Device device,
@@ -58,7 +114,7 @@ void HdAnariMdlMaterial::SyncMaterialParameters(anari::Device device,
     auto terminalNode = con.second.upstreamNodeName;
     auto terminalNodeType = materialNetworkIface.GetNodeType(terminalNode);
 
-  ProcessMdlNode(device,
+    ProcessMdlNode(device,
         material,
         materialNetworkIface,
         terminalNode,
@@ -183,7 +239,8 @@ void HdAnariMdlMaterial::ProcessMdlNode(anari::Device device,
       }
     } else {
       TF_WARN("Don't know how to handle %s of type %s",
-          name.GetText(), value.GetTypeName().c_str());
+          name.GetText(),
+          value.GetTypeName().c_str());
     }
   }
 }

--- a/src/hdanari/rd/material/mdl.cpp
+++ b/src/hdanari/rd/material/mdl.cpp
@@ -142,6 +142,10 @@ void HdAnariMdlMaterial::ProcessMdlNode(anari::Device device,
       terminalNodeType, HdAnariMaterialTokens->mdl);
 
   auto mdlRegistryInstance = HdAnariMdlRegistry::GetInstance();
+  if (!mdlRegistryInstance || !mdlRegistryInstance->getINeuray()) {
+    TF_WARN("MDL registry unavailable; skipping MDL material %s", id.GetText());
+    return; // registry disabled (no INeuray) -> leave material unconfigured
+  }
 
   auto uri = shaderNode->GetResolvedImplementationURI();
 

--- a/src/hdanari/rd/material/mdl.h
+++ b/src/hdanari/rd/material/mdl.h
@@ -15,6 +15,12 @@ struct HdAnariMdlMaterial final
   static anari::Material CreateMaterial(anari::Device device,
       const HdMaterialNetwork2Interface &materialNetworkIface);
 
+  // A content key (MDL material identifier + authored parameter values) that
+  // is independent of the prim path, so content-identical instances share one
+  // anari material. Empty if there is no usable surface terminal.
+  static std::string ComputeContentKey(
+      const HdMaterialNetwork2Interface &materialNetworkIface);
+
   static HdAnariMaterial::PrimvarMapping EnumeratePrimvars(
       const HdMaterialNetwork2Interface &materialNetworkInterface,
       TfToken terminal);

--- a/src/hdanari/rd/material/textureLoader.cpp
+++ b/src/hdanari/rd/material/textureLoader.cpp
@@ -272,7 +272,8 @@ anari::Array2D HdAnariTextureLoader::LoadHioTexture2D(anari::Device d,
     const std::string &file,
     MinMagFilter minMagFilter,
     ColorSpace colorspace,
-    ANARIDataType requestedFormat)
+    ANARIDataType requestedFormat,
+    bool flipVertical)
 {
   const auto image = HioImage::OpenForReading(file);
   if (!image) {
@@ -285,10 +286,12 @@ anari::Array2D HdAnariTextureLoader::LoadHioTexture2D(anari::Device d,
   desc.width = image->GetWidth();
   desc.height = image->GetHeight();
   desc.depth = 1;
-  // Upload top-origin to match ANARI's sampler convention (element (0,0) is the
-  // top scanline). The USD bottom-origin UV convention is reconciled by flipping
-  // the v axis of texture-coordinate primvars in geometry.cpp instead.
-  desc.flipped = false;
+  // Samplers upload top-origin to match ANARI's sampler convention (element
+  // (0,0) is the top scanline); the USD bottom-origin UV convention is
+  // reconciled by flipping the v axis of texture-coordinate primvars in
+  // geometry.cpp. The hdri light instead reads its radiance array bottom-up and
+  // has no primvar to compensate, so the dome opts into a vertical flip.
+  desc.flipped = flipVertical;
 
   auto inputFormat = HioFormatToAnari(desc.format);
   auto outputFormat =

--- a/src/hdanari/rd/material/textureLoader.cpp
+++ b/src/hdanari/rd/material/textureLoader.cpp
@@ -285,7 +285,10 @@ anari::Array2D HdAnariTextureLoader::LoadHioTexture2D(anari::Device d,
   desc.width = image->GetWidth();
   desc.height = image->GetHeight();
   desc.depth = 1;
-  desc.flipped = true;
+  // Upload top-origin to match ANARI's sampler convention (element (0,0) is the
+  // top scanline). The USD bottom-origin UV convention is reconciled by flipping
+  // the v axis of texture-coordinate primvars in geometry.cpp instead.
+  desc.flipped = false;
 
   auto inputFormat = HioFormatToAnari(desc.format);
   auto outputFormat =

--- a/src/hdanari/rd/material/textureLoader.cpp
+++ b/src/hdanari/rd/material/textureLoader.cpp
@@ -19,6 +19,30 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+namespace {
+
+// The REMAP datatype switch (anariTypeHelpers.h) has no FLOAT16 case, so a
+// half-float array would never be populated and would render black. Ask HIO to
+// convert half textures (e.g. ACEScg .exr) to float32 on read instead, which
+// the REMAP path fully supports.
+HioFormat PromoteHalfFloatFormat(HioFormat f)
+{
+  switch (f) {
+  case HioFormatFloat16:
+    return HioFormatFloat32;
+  case HioFormatFloat16Vec2:
+    return HioFormatFloat32Vec2;
+  case HioFormatFloat16Vec3:
+    return HioFormatFloat32Vec3;
+  case HioFormatFloat16Vec4:
+    return HioFormatFloat32Vec4;
+  default:
+    return f;
+  }
+}
+
+} // namespace
+
 anari::DataType HdAnariTextureLoader::HioFormatToAnari(HioFormat f)
 {
   switch (f) {
@@ -282,7 +306,7 @@ anari::Array2D HdAnariTextureLoader::LoadHioTexture2D(anari::Device d,
   }
 
   HioImage::StorageSpec desc;
-  desc.format = image->GetFormat();
+  desc.format = PromoteHalfFloatFormat(image->GetFormat());
   desc.width = image->GetWidth();
   desc.height = image->GetHeight();
   desc.depth = 1;
@@ -320,7 +344,6 @@ anari::Array2D HdAnariTextureLoader::LoadHioTexture2D(anari::Device d,
     TF_WARN("failed to read texture '%s'\n", file.c_str());
     return {};
   }
-
   outputFormat = updateWithColorSpace(outputFormat, ColorSpace::Raw);
 
   TF_DEBUG_MSG(HD_ANARI_RD_MATERIAL,

--- a/src/hdanari/rd/material/textureLoader.h
+++ b/src/hdanari/rd/material/textureLoader.h
@@ -44,11 +44,15 @@ class HdAnariTextureLoader
   };
 
   static anari::DataType HioFormatToAnari(HioFormat f);
+  // flipVertical uploads bottom-origin (element (0,0) is the bottom scanline).
+  // Samplers want top-origin (the default); the hdri light is the lone ANARI
+  // node that reads its radiance array bottom-up, so the dome must opt in.
   static anari::Array2D LoadHioTexture2D(anari::Device d,
       const std::string &file,
       MinMagFilter minMagFilter,
       ColorSpace colorspace,
-      ANARIDataType requestedFormat = ANARI_UNKNOWN);
+      ANARIDataType requestedFormat = ANARI_UNKNOWN,
+      bool flipVertical = false);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/mesh.cpp
+++ b/src/hdanari/rd/mesh.cpp
@@ -6,6 +6,7 @@
 #include "anariTokens.h"
 #include "geometry.h"
 #include "renderParam.h"
+#include "subdivision.h"
 // anari
 #include <anari/anari.h>
 #include <anari/frontend/anari_enums.h>
@@ -68,10 +69,19 @@ void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
 {
   auto renderParam = static_cast<HdAnariRenderParam *>(renderParam_);
 
-  if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())) {
+  if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())
+      || (*dirtyBits & HdChangeTracker::DirtyDisplayStyle)) {
     auto rp = static_cast<HdAnariRenderParam *>(renderParam_);
 
-    topology_ = HdMeshTopology(GetMeshTopology(sceneDelegate), 0);
+    // Refine the control cage to the USD complexity-derived level. When the
+    // mesh isn't refinable (no scheme / level 0 / geom subsets) we keep the
+    // coarse topology. Refinement clears the subdivision scheme, so the result
+    // is treated as a plain polygonal mesh from here on.
+    const HdMeshTopology coarseTopology(GetMeshTopology(sceneDelegate), 0);
+    const int refineLevel = sceneDelegate->GetDisplayStyle(GetId()).refineLevel;
+    subdivision_ = HdAnariSubdivision::Create(coarseTopology, refineLevel);
+    topology_ =
+        subdivision_ ? subdivision_->refinedTopology() : coarseTopology;
     meshUtil_ = std::make_unique<HdAnariMeshUtil>(&topology_, GetId());
 
     meshUtil_->ComputeTriangleIndices(
@@ -255,16 +265,36 @@ HdAnariGeometry::GeomSpecificPrimvars HdAnariMesh::GetGeomSpecificPrimvars(
   // When the prim authors no normals, synthesize crease-aware per-corner
   // normals. Implicit surfaces (sphere, cube, cone, cylinder, capsule, plane)
   // arrive with none, and so do polygonal meshes that omit them.
-  const bool normalIsAuthored =
+  bool normalIsAuthored =
       allPrimvars.find(HdTokens->normals) != std::cend(allPrimvars);
+  // Subdivision refines vertex/varying primvars but drops face-varying ones
+  // (UpdatePrimvarSource returns empty), so face-varying authored normals would
+  // leave the refined surface with none. Treat them as unauthored and
+  // synthesize crease normals instead.
+  if (normalIsAuthored && subdivision_) {
+    for (const auto &pv : sceneDelegate->GetPrimvarDescriptors(
+             GetId(), HdInterpolationFaceVarying)) {
+      if (pv.name == HdTokens->normals) {
+        normalIsAuthored = false;
+        break;
+      }
+    }
+  }
   if (!normalIsAuthored) {
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())
+        || (*dirtyBits & HdChangeTracker::DirtyDisplayStyle)
         || HdChangeTracker::IsPrimvarDirty(
             *dirtyBits, GetId(), HdTokens->points)) {
+      // Normals are per refined corner, so compute them from the refined
+      // points that match triangulatedIndices_.
+      const VtVec3fArray refinedPoints = subdivision_
+          ? subdivision_->Refine(VtValue(points), HdInterpolationVertex)
+                .GetWithDefault<VtVec3fArray>(points)
+          : points;
       anari::release(device_, normals_);
-      normals_ = (std::size(points) > 0 && !triangulatedIndices_.empty())
-          ? _GetAttributeArray(
-                VtValue(_ComputeCreaseNormals(points, triangulatedIndices_)))
+      normals_ = (std::size(refinedPoints) > 0 && !triangulatedIndices_.empty())
+          ? _GetAttributeArray(VtValue(
+                _ComputeCreaseNormals(refinedPoints, triangulatedIndices_)))
           : anari::Array1D{};
     }
     if (normals_)
@@ -283,20 +313,31 @@ HdAnariGeometry::PrimvarSource HdAnariMesh::UpdatePrimvarSource(
     const TfToken &attributeName,
     const VtValue &value)
 {
+  // When refining, interpolate the coarse primvar onto the refined mesh so it
+  // stays consistent with the refined vertices and faces. Face-varying primvars
+  // are not refined in v1 and are dropped (Refine returns an empty value).
+  VtValue refinedValue;
+  if (subdivision_) {
+    refinedValue = subdivision_->Refine(value, interpolation);
+    if (refinedValue.IsEmpty())
+      return {};
+  }
+  const VtValue &pvValue = subdivision_ ? refinedValue : value;
+
   switch (interpolation) {
   case HdInterpolationConstant: {
-    if (value.IsArrayValued()) {
-      if (value.GetArraySize() == 0) {
+    if (pvValue.IsArrayValued()) {
+      if (pvValue.GetArraySize() == 0) {
         TF_RUNTIME_ERROR("Constant interpolation with no value.");
         return {};
       }
-      if (value.GetArraySize() > 1) {
+      if (pvValue.GetArraySize() > 1) {
         TF_RUNTIME_ERROR("Constant interpolation with more than one value.");
       }
     }
 
     GfVec4f v;
-    if (_GetVtValueAsAttribute(value, v)) {
+    if (_GetVtValueAsAttribute(pvValue, v)) {
       return v;
     } else {
       TF_RUNTIME_ERROR(
@@ -307,11 +348,11 @@ HdAnariGeometry::PrimvarSource HdAnariMesh::UpdatePrimvarSource(
   case HdInterpolationUniform: {
     VtValue perFace;
     meshUtil_->GatherPerFacePrimvar(
-        GetId(), attributeName, value, trianglePrimitiveParams_, &perFace);
+        GetId(), attributeName, pvValue, trianglePrimitiveParams_, &perFace);
     return _GetAttributeArray(perFace);
   }
   case HdInterpolationFaceVarying: {
-    HdVtBufferSource buffer(attributeName, value);
+    HdVtBufferSource buffer(attributeName, pvValue);
     VtValue triangulatedPrimvar;
     auto result =
         meshUtil_->ComputeTriangulatedFaceVaryingPrimvar(buffer.GetData(),
@@ -323,7 +364,7 @@ HdAnariGeometry::PrimvarSource HdAnariMesh::UpdatePrimvarSource(
     if (result == HdMeshComputationResult::Success) {
       return _GetAttributeArray(triangulatedPrimvar);
     } else if (result == HdMeshComputationResult::Unchanged) {
-      return _GetAttributeArray(value);
+      return _GetAttributeArray(pvValue);
     } else {
       TF_CODING_ERROR("     ERROR: could not triangulate face-varying data\n");
       return {};
@@ -340,7 +381,7 @@ HdAnariGeometry::PrimvarSource HdAnariMesh::UpdatePrimvarSource(
   }
   case HdInterpolationVarying:
   case HdInterpolationVertex: {
-    return _GetAttributeArray(value);
+    return _GetAttributeArray(pvValue);
   }
   case HdInterpolationInstance:
   case HdInterpolationCount:

--- a/src/hdanari/rd/mesh.cpp
+++ b/src/hdanari/rd/mesh.cpp
@@ -13,6 +13,7 @@
 #include <anari/anari_cpp/anari_cpp_impl.hpp>
 // pxr
 #include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec3i.h>
 #include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticData.h>
@@ -25,11 +26,9 @@
 #include <pxr/imaging/hd/geomSubset.h>
 #include <pxr/imaging/hd/meshUtil.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
-#include <pxr/imaging/hd/smoothNormals.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/types.h>
 #include <pxr/imaging/hd/vtBufferSource.h>
-#include <pxr/imaging/pxOsd/tokens.h>
 // std
 #include <cassert>
 #include <iterator>
@@ -74,7 +73,6 @@ void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
 
     topology_ = HdMeshTopology(GetMeshTopology(sceneDelegate), 0);
     meshUtil_ = std::make_unique<HdAnariMeshUtil>(&topology_, GetId());
-    adjacency_.reset();
 
     meshUtil_->ComputeTriangleIndices(
         &triangulatedIndices_, &trianglePrimitiveParams_);
@@ -186,6 +184,55 @@ HdGeomSubsets HdAnariMesh::GetGeomSubsets(
   return geomsubsets_;
 }
 
+// Per-corner (faceVarying) normals with crease splitting: a vertex's incident
+// face normals are accumulated only within an angle threshold, so smooth
+// regions stay smooth (sphere) while sharp features keep hard edges (cube
+// edges, cone/cylinder caps). USD ships no normals for implicit surfaces, and
+// plain adjacency averaging flattens capped shapes by blending the cap and
+// side normals into their shared rim vertices.
+static constexpr float kCosCreaseThreshold = 0.342f; // cos(70 degrees)
+
+static GfVec3f _SafeNormalize(const GfVec3f &v)
+{
+  const float len = v.GetLength();
+  return len > 0.0f ? v / len : GfVec3f(0.0f);
+}
+
+static VtVec3fArray _ComputeCreaseNormals(
+    const VtVec3fArray &points, const VtVec3iArray &triangles)
+{
+  const size_t numTris = std::size(triangles);
+
+  std::vector<GfVec3f> faceNormal(numTris); // normalized, for the angle test
+  std::vector<GfVec3f> faceWeighted(numTris); // area-weighted, for accumulation
+  for (size_t t = 0; t < numTris; ++t) {
+    const GfVec3i &tri = triangles[t];
+    const GfVec3f &p0 = points[tri[0]];
+    const GfVec3f cross = GfCross(points[tri[1]] - p0, points[tri[2]] - p0);
+    faceWeighted[t] = cross; // length is proportional to twice the area
+    faceNormal[t] = _SafeNormalize(cross);
+  }
+
+  std::vector<std::vector<int>> incidentTriangles(std::size(points));
+  for (size_t t = 0; t < numTris; ++t)
+    for (int c = 0; c < 3; ++c)
+      incidentTriangles[triangles[t][c]].push_back(int(t));
+
+  VtVec3fArray normals(3 * numTris);
+  for (size_t t = 0; t < numTris; ++t) {
+    for (int c = 0; c < 3; ++c) {
+      GfVec3f acc(0.0f);
+      for (int other : incidentTriangles[triangles[t][c]]) {
+        if (GfDot(faceNormal[t], faceNormal[other]) >= kCosCreaseThreshold)
+          acc += faceWeighted[other];
+      }
+      const GfVec3f n = _SafeNormalize(acc);
+      normals[3 * t + c] = (n == GfVec3f(0.0f)) ? faceNormal[t] : n;
+    }
+  }
+  return normals;
+}
+
 HdAnariGeometry::GeomSpecificPrimvars HdAnariMesh::GetGeomSpecificPrimvars(
     HdSceneDelegate *sceneDelegate,
     HdDirtyBits *dirtyBits,
@@ -205,33 +252,23 @@ HdAnariGeometry::GeomSpecificPrimvars HdAnariMesh::GetGeomSpecificPrimvars(
         {HdAnariTokens->primitiveIndex, geomSubsetTriangles_[geomsetId]});
   }
 
-  // Normals smoothing if needed.
-  const auto &normals = sceneDelegate->Get(GetId(), HdTokens->normals);
-  bool normalIsAuthored =
+  // When the prim authors no normals, synthesize crease-aware per-corner
+  // normals. Implicit surfaces (sphere, cube, cone, cylinder, capsule, plane)
+  // arrive with none, and so do polygonal meshes that omit them.
+  const bool normalIsAuthored =
       allPrimvars.find(HdTokens->normals) != std::cend(allPrimvars);
-  bool doSmoothNormals = (topology_.GetScheme() != PxOsdOpenSubdivTokens->none)
-      && (topology_.GetScheme() != PxOsdOpenSubdivTokens->bilinear);
-
-  if (!normalIsAuthored && doSmoothNormals) {
+  if (!normalIsAuthored) {
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())
         || HdChangeTracker::IsPrimvarDirty(
             *dirtyBits, GetId(), HdTokens->points)) {
-      if (!adjacency_.has_value()) {
-        adjacency_.emplace();
-        adjacency_->BuildAdjacencyTable(&topology_);
-      }
-
       anari::release(device_, normals_);
-
-      if (TF_VERIFY(std::size(points) > 0)) {
-        const VtVec3fArray &normals = Hd_SmoothNormals::ComputeSmoothNormals(
-            &*adjacency_, std::size(points), std::cbegin(points));
-        normals_ = _GetAttributeArray(VtValue(normals));
-        primvars.push_back({HdAnariTokens->vertexNormal, normals_});
-      } else {
-        normals_ = {};
-      }
+      normals_ = (std::size(points) > 0 && !triangulatedIndices_.empty())
+          ? _GetAttributeArray(
+                VtValue(_ComputeCreaseNormals(points, triangulatedIndices_)))
+          : anari::Array1D{};
     }
+    if (normals_)
+      primvars.push_back({HdAnariTokens->faceVaryingNormal, normals_});
   } else {
     anari::release(device_, normals_);
     normals_ = {};

--- a/src/hdanari/rd/mesh.cpp
+++ b/src/hdanari/rd/mesh.cpp
@@ -122,34 +122,62 @@ void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
       // We go a slightly different path here.
       // In order to be able to share faceVarying and face primvars between
       // subsets, we generate degenerate triangles for triangles not belonging
-      // to the subset, so all topology have the same size.
-      for (auto subset : geomsubsets_) {
-        auto id = subset.id;
+      // to the subset, so all topology have the same size. Seed from the first
+      // index; when the mesh triangulates to nothing the seed is unused (the
+      // built index arrays are empty), so avoid indexing an empty array.
+      const GfVec3i degenerate = triangulatedIndices_.empty()
+          ? GfVec3i(0)
+          : GfVec3i(triangulatedIndices_[trianglesStarts[0]][0]);
 
-        // Fill with a degenerate triangle, that is using vertices from the
-        // actual geomsubset so its extent stays valid.
-        VtVec3iArray indices(triangulatedIndices_.size(),
-            GfVec3i(triangulatedIndices_[trianglesStarts[0]][0]));
+      // Track which faces a subset claims so we can render the remainder (faces
+      // covered by no subset) with the prim's own material below.
+      std::vector<bool> faceCovered(trianglesCounts.size(), false);
 
-        for (auto i : subset.indices) {
-          auto trianglesStart = trianglesStarts[i];
-          auto trianglesCount = trianglesCounts[i];
-
-          for (auto i = 0; i < trianglesCount; ++i) {
-            indices[trianglesStart + i] =
-                triangulatedIndices_[trianglesStart + i];
+      auto buildTriangles = [&](const auto &faceIndices) {
+        VtVec3iArray indices(triangulatedIndices_.size(), degenerate);
+        for (auto faceIndex : faceIndices) {
+          auto trianglesStart = trianglesStarts[faceIndex];
+          auto trianglesCount = trianglesCounts[faceIndex];
+          for (auto t = 0; t < trianglesCount; ++t) {
+            indices[trianglesStart + t] =
+                triangulatedIndices_[trianglesStart + t];
           }
         }
+        return _GetAttributeArray(VtValue(indices), ANARI_UINT32_VEC3);
+      };
 
-        auto subsetTriangles =
-            _GetAttributeArray(VtValue(indices), ANARI_UINT32_VEC3);
-        geomSubsetTriangles_[id] = subsetTriangles;
+      for (auto subset : geomsubsets_) {
+        for (auto faceIndex : subset.indices)
+          faceCovered[faceIndex] = true;
+        geomSubsetTriangles_[subset.id] = buildTriangles(subset.indices);
       }
+
+      // A geomsubset partition need not cover every face. Faces left over use
+      // the prim's own material; without this they would never be rendered.
+      if (auto it = geomSubsetTriangles_.find(GetId());
+          it != cend(geomSubsetTriangles_)) {
+        anari::release(device_, it->second);
+        geomSubsetTriangles_.erase(it);
+      }
+      VtIntArray remainderFaces;
+      for (size_t faceIndex = 0; faceIndex < faceCovered.size(); ++faceIndex) {
+        if (!faceCovered[faceIndex])
+          remainderFaces.push_back(int(faceIndex));
+      }
+      if (!remainderFaces.empty())
+        geomSubsetTriangles_[GetId()] = buildTriangles(remainderFaces);
     }
   }
 
   // Call the main geometry sync.
   HdAnariGeometry::Sync(sceneDelegate, renderParam_, dirtyBits, reprToken);
+}
+
+bool HdAnariMesh::HasMainGeometry() const
+{
+  // Present either when there are no subsets (full triangulation) or when a
+  // subset partition leaves uncovered faces (the remainder triangle set).
+  return geomSubsetTriangles_.count(GetId()) > 0;
 }
 
 HdGeomSubsets HdAnariMesh::GetGeomSubsets(

--- a/src/hdanari/rd/mesh.cpp
+++ b/src/hdanari/rd/mesh.cpp
@@ -71,8 +71,6 @@ void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
 
   if (HdChangeTracker::IsTopologyDirty(*dirtyBits, GetId())
       || (*dirtyBits & HdChangeTracker::DirtyDisplayStyle)) {
-    auto rp = static_cast<HdAnariRenderParam *>(renderParam_);
-
     // Refine the control cage to the USD complexity-derived level. When the
     // mesh isn't refinable (no scheme / level 0 / geom subsets) we keep the
     // coarse topology. Refinement clears the subdivision scheme, so the result
@@ -80,37 +78,26 @@ void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
     const HdMeshTopology coarseTopology(GetMeshTopology(sceneDelegate), 0);
     const int refineLevel = sceneDelegate->GetDisplayStyle(GetId()).refineLevel;
     subdivision_ = HdAnariSubdivision::Create(coarseTopology, refineLevel);
-    topology_ =
-        subdivision_ ? subdivision_->refinedTopology() : coarseTopology;
+    topology_ = subdivision_ ? subdivision_->refinedTopology() : coarseTopology;
     meshUtil_ = std::make_unique<HdAnariMeshUtil>(&topology_, GetId());
 
     meshUtil_->ComputeTriangleIndices(
         &triangulatedIndices_, &trianglePrimitiveParams_);
 
-    // Create transient mapping structure to be able to map a face to its
-    // subdivised triangles. To be used to build geomsubset topology.
-    VtIntArray trianglesCounts;
-
-    auto count = 1ull;
-    auto prev = HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(
-        trianglePrimitiveParams_.front());
-    for (auto i = 1ull; i < trianglePrimitiveParams_.size(); ++i) {
-      auto pp = trianglePrimitiveParams_[i];
+    // Map each coarse face to its triangulated triangle span. Indexed by true
+    // coarse face index (not order-of-appearance): a face that triangulates to
+    // zero triangles keeps a count of 0 and an empty span, so geom-subset face
+    // indices stay in bounds even when an earlier face is degenerate.
+    const int numFaces = topology_.GetNumFaces();
+    VtIntArray trianglesCounts(numFaces, 0);
+    for (auto pp : trianglePrimitiveParams_) {
       int faceIndex = HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(pp);
-      if (faceIndex != prev) {
-        trianglesCounts.push_back(count);
-        prev = faceIndex;
-        count = 1;
-      } else {
-        ++count;
-      }
+      ++trianglesCounts[faceIndex];
     }
-    trianglesCounts.push_back(count);
 
-    VtIntArray trianglesStarts(1, 0);
-    for (auto i = 0; i < trianglesCounts.size(); ++i) {
-      trianglesStarts.push_back(trianglesStarts.back() + trianglesCounts[i]);
-    }
+    VtIntArray trianglesStarts(numFaces + 1, 0);
+    for (int i = 0; i < numFaces; ++i)
+      trianglesStarts[i + 1] = trianglesStarts[i] + trianglesCounts[i];
 
     // Build topology/triangle sets for each subgeom.
     // Release any previously owned anari array before assigning the new one.
@@ -157,6 +144,12 @@ void HdAnariMesh::Sync(HdSceneDelegate *sceneDelegate,
       for (auto subset : geomsubsets_) {
         for (auto faceIndex : subset.indices)
           faceCovered[faceIndex] = true;
+        // Release any array previously held for this subset before replacing
+        // it; this block re-runs on DirtyDisplayStyle, not just topology
+        // change.
+        if (auto it = geomSubsetTriangles_.find(subset.id);
+            it != cend(geomSubsetTriangles_))
+          anari::release(device_, it->second);
         geomSubsetTriangles_[subset.id] = buildTriangles(subset.indices);
       }
 

--- a/src/hdanari/rd/mesh.h
+++ b/src/hdanari/rd/mesh.h
@@ -29,6 +29,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdAnariSubdivision;
+
 class HdAnariMesh final : public HdAnariGeometry
 {
  public:
@@ -68,6 +70,7 @@ class HdAnariMesh final : public HdAnariGeometry
 
   HdMeshTopology topology_;
   std::unique_ptr<HdAnariMeshUtil> meshUtil_;
+  std::unique_ptr<HdAnariSubdivision> subdivision_;
 
   HdGeomSubsets geomsubsets_;
 

--- a/src/hdanari/rd/mesh.h
+++ b/src/hdanari/rd/mesh.h
@@ -49,6 +49,7 @@ class HdAnariMesh final : public HdAnariGeometry
   void Finalize(HdRenderParam *renderParam_) override;
 
  protected:
+  bool HasMainGeometry() const override;
   HdGeomSubsets GetGeomSubsets(
       HdSceneDelegate *sceneDelegate, HdDirtyBits *dirtyBits) override;
   HdAnariGeometry::GeomSpecificPrimvars GetGeomSpecificPrimvars(

--- a/src/hdanari/rd/mesh.h
+++ b/src/hdanari/rd/mesh.h
@@ -20,13 +20,11 @@
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/types.h>
-#include <pxr/imaging/hd/vertexAdjacency.h>
 #include <pxr/imaging/hf/perfLog.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
 // std
 #include <memory>
-#include <optional>
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -70,7 +68,6 @@ class HdAnariMesh final : public HdAnariGeometry
 
   HdMeshTopology topology_;
   std::unique_ptr<HdAnariMeshUtil> meshUtil_;
-  std::optional<Hd_VertexAdjacency> adjacency_;
 
   HdGeomSubsets geomsubsets_;
 

--- a/src/hdanari/rd/plugInfo.json.in
+++ b/src/hdanari/rd/plugInfo.json.in
@@ -6,6 +6,12 @@
           "bases": ["HdRendererPlugin"],
           "displayName": "Anari",
           "priority": 99
+        },
+        "HdAnari_ImplicitSurfaceSceneIndexPlugin": {
+          "bases": ["HdSceneIndexPlugin"],
+          "loadWithRenderer": "Anari",
+          "priority": 0,
+          "displayName": "Scene Index to turn implicit surfaces into meshes suitable for HdAnari"
         }
       }
     },

--- a/src/hdanari/rd/renderBuffer.cpp
+++ b/src/hdanari/rd/renderBuffer.cpp
@@ -7,6 +7,9 @@
 #include <pxr/base/gf/half.h>
 #include <pxr/imaging/hd/tokens.h>
 
+#include <algorithm>
+#include <cstring>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 // Helper functions ///////////////////////////////////////////////////////////
@@ -84,6 +87,33 @@ static void _WriteOutput(
 static size_t _GetBufferSize(GfVec2i const &dims, HdFormat format)
 {
   return dims[0] * dims[1] * HdDataSizeOfFormat(format);
+}
+
+// ACES filmic tonemap (Narkowicz approximation). Compresses linear HDR
+// radiance into [0, 1] so bright (e.g. dome-lit) scenes don't clamp to white.
+static float _AcesToneMap(float x)
+{
+  constexpr float a = 2.51f;
+  constexpr float b = 0.03f;
+  constexpr float c = 2.43f;
+  constexpr float d = 0.59f;
+  constexpr float e = 0.14f;
+  const float y = (x * (a * x + b)) / (x * (c * x + d) + e);
+  return std::clamp(y, 0.0f, 1.0f);
+}
+
+// Apply exposure (linear scale) and optional ACES tonemapping to the RGB of a
+// float32 RGBA color buffer in place, preserving alpha.
+static void _ProcessColorFloat4(
+    uint8_t *data, size_t pixelCount, float exposureScale, bool tonemap)
+{
+  auto *rgba = reinterpret_cast<float *>(data);
+  for (size_t i = 0; i < pixelCount; ++i) {
+    for (int c = 0; c < 3; ++c) {
+      const float v = rgba[4 * i + c] * exposureScale;
+      rgba[4 * i + c] = tonemap ? _AcesToneMap(v) : v;
+    }
+  }
 }
 
 static HdFormat _GetSampleFormat(HdFormat format)
@@ -204,7 +234,9 @@ void HdAnariRenderBuffer::SetConverged(bool cv)
 void HdAnariRenderBuffer::CopyFromAnariFrame(anari::Device d,
     anari::Frame f,
     const TfToken &aovName,
-    const VtValue &clearValue)
+    const VtValue &clearValue,
+    float exposureScale,
+    bool tonemap)
 {
   auto setData = [&](const char *channel, bool checkPixelType) -> bool {
     auto fb = anari::map<void>(d, f, channel);
@@ -242,9 +274,14 @@ void HdAnariRenderBuffer::CopyFromAnariFrame(anari::Device d,
 
   bool dataWritten = false;
 
-  if (aovName == HdAovTokens->color)
+  if (aovName == HdAovTokens->color) {
     dataWritten = setData("channel.color", true);
-  else if (aovName == HdAovTokens->cameraDepth || aovName == HdAovTokens->depth)
+    const bool needsProcessing = tonemap || exposureScale != 1.0f;
+    if (dataWritten && needsProcessing && _format == HdFormatFloat32Vec4)
+      _ProcessColorFloat4(
+          _buffer.data(), size_t(_width) * _height, exposureScale, tonemap);
+  } else if (aovName == HdAovTokens->cameraDepth
+      || aovName == HdAovTokens->depth)
     dataWritten = setData("channel.depth", true);
   else if (aovName == HdAovTokens->elementId)
     dataWritten = setData("channel.primitiveId", false);

--- a/src/hdanari/rd/renderBuffer.h
+++ b/src/hdanari/rd/renderBuffer.h
@@ -36,7 +36,9 @@ struct HdAnariRenderBuffer : public HdRenderBuffer
   void CopyFromAnariFrame(anari::Device d,
       anari::Frame f,
       const TfToken &aovName,
-      const VtValue &clearValue);
+      const VtValue &clearValue,
+      float exposureScale = 1.0f,
+      bool tonemap = false);
 
   void Clear(const VtValue &clearValue);
 

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -11,6 +11,7 @@
 #include "mesh.h"
 #include "points.h"
 #include "renderBuffer.h"
+#include "renderSettings.h"
 #include "renderParam.h"
 #include "renderPass.h"
 
@@ -97,6 +98,7 @@ const TfTokenVector HdAnariRenderDelegate::SUPPORTED_SPRIM_TYPES = {
 
 const TfTokenVector HdAnariRenderDelegate::SUPPORTED_BPRIM_TYPES = {
     HdPrimTypeTokens->renderBuffer,
+    HdPrimTypeTokens->renderSettings,
 };
 
 std::mutex HdAnariRenderDelegate::_mutexResourceRegistry;
@@ -221,6 +223,12 @@ HdAnariRenderDelegate::GetRenderSettingDescriptors() const
 {
   std::lock_guard<std::mutex> guard(_settingsMutex);
   return _settingDescriptors;
+}
+
+TfTokenVector HdAnariRenderDelegate::GetRenderSettingsNamespaces() const
+{
+  static const TfTokenVector namespaces = {TfToken("anari")};
+  return namespaces;
 }
 
 HdAnariRendererParamList HdAnariRenderDelegate::GetRendererParameters() const
@@ -458,6 +466,8 @@ HdBprim *HdAnariRenderDelegate::CreateBprim(
 {
   if (typeId == HdPrimTypeTokens->renderBuffer)
     return new HdAnariRenderBuffer(bprimId);
+  if (typeId == HdPrimTypeTokens->renderSettings)
+    return new HdAnariRenderSettings(bprimId);
 
   TF_CODING_ERROR("Unknown Bprim Type %s", typeId.GetText());
 
@@ -468,6 +478,8 @@ HdBprim *HdAnariRenderDelegate::CreateFallbackBprim(TfToken const &typeId)
 {
   if (typeId == HdPrimTypeTokens->renderBuffer)
     return new HdAnariRenderBuffer(SdfPath::EmptyPath());
+  if (typeId == HdPrimTypeTokens->renderSettings)
+    return new HdAnariRenderSettings(SdfPath::EmptyPath());
 
   TF_CODING_ERROR("Unknown Bprim Type %s", typeId.GetText());
 

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -163,7 +163,8 @@ void HdAnariRenderDelegate::Initialize()
 
   auto device = anari::newDevice(library, "default");
 #ifdef HDANARI_ENABLE_MDL
-  if (mdlRegistryInstance && hasANARI_VISRTX_MATERIAL_MDL) {
+  if (mdlRegistryInstance && mdlRegistryInstance->getINeuray()
+      && hasANARI_VISRTX_MATERIAL_MDL) {
     anari::setParameter(device,
         device,
         "ineuray",

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -139,7 +139,7 @@ void HdAnariRenderDelegate::Initialize()
     else if ("ANARI_KHR_MATERIAL_PHYSICALLY_BASED"sv == *e)
       hasANARI_KHR_MATERIAL_PHYSICALLY_BASED = true;
 #ifdef HDANARI_ENABLE_MDL
-    else if ("ANARI_VISRTX_MATERIAL_MDL_SURFACE"sv == *e)
+    else if ("ANARI_VISRTX_MATERIAL_MDL"sv == *e)
       hasANARI_VISRTX_MATERIAL_MDL = true;
 #endif
   }

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -141,6 +141,15 @@ void HdAnariRenderDelegate::Initialize()
   _settingDescriptors.push_back(
       {"Denoise", HdAnariRenderSettingsTokens->denoise, VtValue(false)});
 
+  // VisRTX outputs linear radiance with no display tonemapping or exposure.
+  // Exposure (EV stops) scales the color AOV by 2^exposure to bring an
+  // over/under-lit scene into range; tonemap then applies an ACES filmic
+  // curve to compress remaining highlights. Both default to off/neutral.
+  _settingDescriptors.push_back(
+      {"Exposure", HdAnariRenderSettingsTokens->exposure, VtValue(0.0f)});
+  _settingDescriptors.push_back(
+      {"Tonemap", HdAnariRenderSettingsTokens->tonemap, VtValue(false)});
+
   _settingDescriptors.push_back({"subtype",
       HdAnariRenderSettingsTokens->renderSubtype,
       VtValue("default")});

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -223,9 +223,10 @@ HdAnariRenderDelegate::GetRenderSettingDescriptors() const
   return _settingDescriptors;
 }
 
-const HdAnariRendererParamList &
-HdAnariRenderDelegate::GetRendererParameters() const
+HdAnariRendererParamList HdAnariRenderDelegate::GetRendererParameters() const
 {
+  // Return a copy: a concurrent SyncActiveRendererSubtype reallocates
+  // _rendererParams, so a reference would dangle while the caller iterates.
   std::lock_guard<std::mutex> guard(_settingsMutex);
   return _rendererParams;
 }

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -117,55 +117,6 @@ HdAnariRenderDelegate::HdAnariRenderDelegate(
 
 void HdAnariRenderDelegate::Initialize()
 {
-  // Initialize the settings and settings descriptors.
-  _settingDescriptors.clear();
-  _settingDescriptors.push_back({"Ambient Radiance",
-      HdAnariRenderSettingsTokens->ambientRadiance,
-      VtValue(0.2f)});
-  _settingDescriptors.push_back({"Ambient Color",
-      HdAnariRenderSettingsTokens->ambientColor,
-      VtValue(GfVec3f(0.8f, 0.8f, 0.8f))});
-  _settingDescriptors.push_back({"Ambient Samples",
-      HdAnariRenderSettingsTokens->ambientSamples,
-      VtValue(1)});
-
-  _settingDescriptors.push_back(
-      {"Sample Limit", HdAnariRenderSettingsTokens->sampleLimit, VtValue(128)});
-
-  _settingDescriptors.push_back(
-      {"Max Ray Depth", HdAnariRenderSettingsTokens->maxRayDepth, VtValue(0)});
-
-  _settingDescriptors.push_back(
-      {"Pixel Samples", HdAnariRenderSettingsTokens->pixelSamples, VtValue(1)});
-
-  _settingDescriptors.push_back(
-      {"Denoise", HdAnariRenderSettingsTokens->denoise, VtValue(false)});
-
-  // VisRTX outputs linear radiance with no display tonemapping or exposure.
-  // Exposure (EV stops) scales the color AOV by 2^exposure to bring an
-  // over/under-lit scene into range; tonemap then applies an ACES filmic
-  // curve to compress remaining highlights. Both default to off/neutral.
-  _settingDescriptors.push_back(
-      {"Exposure", HdAnariRenderSettingsTokens->exposure, VtValue(0.0f)});
-  _settingDescriptors.push_back(
-      {"Tonemap", HdAnariRenderSettingsTokens->tonemap, VtValue(false)});
-
-  // Stage up axis used to resolve a dome light's poleAxis="scene". A Hydra
-  // render delegate has no direct access to UsdGeomGetStageUpAxis, so the host
-  // supplies it here; defaults to USD's "Y".
-  _settingDescriptors.push_back({"Stage Up Axis",
-      HdAnariRenderSettingsTokens->upAxis,
-      VtValue(TfToken("Y"))});
-
-  _settingDescriptors.push_back({"subtype",
-      HdAnariRenderSettingsTokens->renderSubtype,
-      VtValue("default")});
-  _settingDescriptors.push_back({"debug:method",
-      HdAnariRenderSettingsTokens->debugMethod,
-      VtValue("Ns.abs")});
-
-  _PopulateDefaultSettings(_settingDescriptors);
-
   auto library = anari::loadLibrary("environment", hdAnariDeviceStatusFunc);
   if (!library) {
     TF_RUNTIME_ERROR("failed to load ANARI library from environment");
@@ -216,6 +167,14 @@ void HdAnariRenderDelegate::Initialize()
     return;
   }
 
+  // Derive the render-setting descriptors from device introspection. Every
+  // ANARI renderer supports the "default" subtype, so start there; the host can
+  // switch via the renderSubtype setting.
+  {
+    std::lock_guard<std::mutex> guard(_settingsMutex);
+    _SetActiveRendererSubtypeLocked(device, "default");
+  }
+
   HdAnariMaterial::MaterialType materialType =
       hasANARI_KHR_MATERIAL_PHYSICALLY_BASED
       ? HdAnariMaterial::MaterialType::PhysicallyBased
@@ -245,7 +204,59 @@ HdAnariRenderDelegate::~HdAnariRenderDelegate()
 HdRenderSettingDescriptorList
 HdAnariRenderDelegate::GetRenderSettingDescriptors() const
 {
+  std::lock_guard<std::mutex> guard(_settingsMutex);
   return _settingDescriptors;
+}
+
+const HdAnariRendererParamList &
+HdAnariRenderDelegate::GetRendererParameters() const
+{
+  std::lock_guard<std::mutex> guard(_settingsMutex);
+  return _rendererParams;
+}
+
+void HdAnariRenderDelegate::SyncActiveRendererSubtype(
+    const std::string &subtype)
+{
+  std::lock_guard<std::mutex> guard(_settingsMutex);
+  if (subtype == _activeRendererSubtype)
+    return;
+  _SetActiveRendererSubtypeLocked(_renderParam->GetANARIDevice(), subtype);
+}
+
+void HdAnariRenderDelegate::_SetActiveRendererSubtypeLocked(
+    anari::Device device, const std::string &subtype)
+{
+  _activeRendererSubtype = subtype;
+  _rendererParams = HdAnariQueryRendererParameters(device, subtype.c_str());
+  _BuildSettingDescriptorsLocked();
+  _PopulateDefaultSettings(_settingDescriptors);
+}
+
+void HdAnariRenderDelegate::_BuildSettingDescriptorsLocked()
+{
+  _settingDescriptors.clear();
+
+  // Host-owned settings with no ANARI renderer counterpart.
+  _settingDescriptors.push_back({"subtype",
+      HdAnariRenderSettingsTokens->renderSubtype,
+      VtValue(_activeRendererSubtype)});
+  // Stage up axis used to resolve a dome light's poleAxis="scene". A Hydra
+  // render delegate has no direct access to UsdGeomGetStageUpAxis, so the host
+  // supplies it here; defaults to USD's "Y".
+  _settingDescriptors.push_back({"Stage Up Axis",
+      HdAnariRenderSettingsTokens->upAxis,
+      VtValue(TfToken("Y"))});
+  // Exposure (EV stops) scales the color AOV by 2^exposure; tonemap applies an
+  // ACES filmic curve. Both are applied by hdanari, not the ANARI renderer.
+  _settingDescriptors.push_back(
+      {"Exposure", HdAnariRenderSettingsTokens->exposure, VtValue(0.0f)});
+  _settingDescriptors.push_back(
+      {"Tonemap", HdAnariRenderSettingsTokens->tonemap, VtValue(false)});
+
+  // Renderer parameters discovered from the device, keyed by ANARI name.
+  for (const auto &param : _rendererParams)
+    _settingDescriptors.push_back({param.name, param.key, param.defaultValue});
 }
 
 HdAnariRenderParam *HdAnariRenderDelegate::GetRenderParam() const
@@ -303,10 +314,18 @@ HdAovDescriptor HdAnariRenderDelegate::GetDefaultAovDescriptor(
 VtDictionary HdAnariRenderDelegate::GetRenderStats() const
 {
   VtDictionary stats;
-#if 0
-  stats[HdPerfTokens->numCompletedSamples.GetString()] =
-      _renderer.GetCompletedSamples();
-#endif
+  if (!_renderParam)
+    return stats;
+
+  const int completedSamples = _renderParam->CompletedSamples();
+  const int sampleLimit = _renderParam->SampleLimit();
+
+  stats[HdPerfTokens->numCompletedSamples.GetString()] = completedSamples;
+  if (sampleLimit > 0) {
+    stats["totalSamples"] = sampleLimit;
+    stats["percentDone"] = 100.0 * completedSamples / sampleLimit;
+  }
+
   return stats;
 }
 

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -136,7 +136,7 @@ void HdAnariRenderDelegate::Initialize()
       {"Max Ray Depth", HdAnariRenderSettingsTokens->maxRayDepth, VtValue(0)});
 
   _settingDescriptors.push_back(
-      { "Pixel Samples",HdAnariRenderSettingsTokens->pixelSamples, VtValue(1) });
+      {"Pixel Samples", HdAnariRenderSettingsTokens->pixelSamples, VtValue(1)});
 
   _settingDescriptors.push_back(
       {"Denoise", HdAnariRenderSettingsTokens->denoise, VtValue(false)});
@@ -149,6 +149,13 @@ void HdAnariRenderDelegate::Initialize()
       {"Exposure", HdAnariRenderSettingsTokens->exposure, VtValue(0.0f)});
   _settingDescriptors.push_back(
       {"Tonemap", HdAnariRenderSettingsTokens->tonemap, VtValue(false)});
+
+  // Stage up axis used to resolve a dome light's poleAxis="scene". A Hydra
+  // render delegate has no direct access to UsdGeomGetStageUpAxis, so the host
+  // supplies it here; defaults to USD's "Y".
+  _settingDescriptors.push_back({"Stage Up Axis",
+      HdAnariRenderSettingsTokens->upAxis,
+      VtValue(TfToken("Y"))});
 
   _settingDescriptors.push_back({"subtype",
       HdAnariRenderSettingsTokens->renderSubtype,

--- a/src/hdanari/rd/renderDelegate.cpp
+++ b/src/hdanari/rd/renderDelegate.cpp
@@ -139,7 +139,7 @@ void HdAnariRenderDelegate::Initialize()
     else if ("ANARI_KHR_MATERIAL_PHYSICALLY_BASED"sv == *e)
       hasANARI_KHR_MATERIAL_PHYSICALLY_BASED = true;
 #ifdef HDANARI_ENABLE_MDL
-    else if ("ANARI_VISRTX_MATERIAL_MDL"sv == *e)
+    else if ("ANARI_VISRTX_MATERIAL_MDL_SURFACE"sv == *e)
       hasANARI_VISRTX_MATERIAL_MDL = true;
 #endif
   }
@@ -149,16 +149,30 @@ void HdAnariRenderDelegate::Initialize()
     return;
   }
 
+#ifdef HDANARI_ENABLE_MDL
+  // Build the MDL registry once, single-threaded, BEFORE the device exists, so
+  // HdAnari owns the MDL SDK's single INeuray and the device reuses it.
+  // Unconditional: the SDR parser and the <mdl> material backend call
+  // GetInstance() during Sync (on worker threads). If the registry is first
+  // built there, its default ctor self-acquires a second INeuray, throws
+  // (already held by the device), and poisons the TfSingleton -> every later
+  // GetInstance() spins forever. So acquire it here, regardless of the device
+  // extension, before anything can race on it.
+  auto *mdlRegistryInstance = HdAnariMdlRegistry::GetInstance();
+#endif
+
   auto device = anari::newDevice(library, "default");
 #ifdef HDANARI_ENABLE_MDL
-  if (hasANARI_VISRTX_MATERIAL_MDL) {
-    if (auto mdlRegistryInstance = HdAnariMdlRegistry::GetInstance()) {
-      anari::setParameter(device,
-          device,
-          "ineuray",
-          ANARI_VOID_POINTER,
-          mdlRegistryInstance->getINeuray());
-    }
+  if (mdlRegistryInstance && hasANARI_VISRTX_MATERIAL_MDL) {
+    anari::setParameter(device,
+        device,
+        "ineuray",
+        ANARI_VOID_POINTER,
+        mdlRegistryInstance->getINeuray());
+    // Device parameters only take effect once committed; without this the
+    // device never receives our shared INeuray and MDL material support
+    // silently fails to initialize.
+    anari::commitParameters(device, device);
   }
 #endif
 

--- a/src/hdanari/rd/renderDelegate.h
+++ b/src/hdanari/rd/renderDelegate.h
@@ -53,6 +53,11 @@ class HdAnariRenderDelegate final : public HdRenderDelegate
 
   HdRenderSettingDescriptorList GetRenderSettingDescriptors() const override;
 
+  // Namespace prefix for render settings authored on a UsdRenderSettings prim
+  // (e.g. `anari:renderSubtype`). USD only surfaces namespaced attributes as
+  // namespacedSettings; this tells usdImaging to collect the "anari" ones.
+  TfTokenVector GetRenderSettingsNamespaces() const override;
+
   // Renderer parameters discovered for the active subtype, consumed by the
   // render pass to forward host render settings to the ANARI renderer.
   HdAnariRendererParamList GetRendererParameters() const;

--- a/src/hdanari/rd/renderDelegate.h
+++ b/src/hdanari/rd/renderDelegate.h
@@ -55,7 +55,7 @@ class HdAnariRenderDelegate final : public HdRenderDelegate
 
   // Renderer parameters discovered for the active subtype, consumed by the
   // render pass to forward host render settings to the ANARI renderer.
-  const HdAnariRendererParamList &GetRendererParameters() const;
+  HdAnariRendererParamList GetRendererParameters() const;
 
   // Re-query parameters and rebuild the render-setting descriptors when the
   // render pass switches the active renderer subtype. No-op if unchanged.

--- a/src/hdanari/rd/renderDelegate.h
+++ b/src/hdanari/rd/renderDelegate.h
@@ -26,9 +26,11 @@ class HdAnariRenderParam;
   (debugMethod) \
   (denoise) \
   (maxRayDepth) \
+  (exposure) \
   (pixelSamples) \
   (renderSubtype) \
-  (sampleLimit)
+  (sampleLimit) \
+  (tonemap)
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(

--- a/src/hdanari/rd/renderDelegate.h
+++ b/src/hdanari/rd/renderDelegate.h
@@ -30,7 +30,8 @@ class HdAnariRenderParam;
   (pixelSamples) \
   (renderSubtype) \
   (sampleLimit) \
-  (tonemap)
+  (tonemap) \
+  (upAxis)
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(

--- a/src/hdanari/rd/renderDelegate.h
+++ b/src/hdanari/rd/renderDelegate.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "renderParam.h"
+#include "rendererParameters.h"
 
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/token.h>
@@ -13,23 +14,21 @@
 
 #include <anari/anari_cpp.hpp>
 #include <mutex>
+#include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdAnariRenderParam;
 
+// Render settings hdanari owns directly; every other renderer parameter is
+// discovered from the device and keyed by its verbatim ANARI name.
+//   renderSubtype: selects the ANARI renderer subtype.
+//   upAxis:        stage up axis, resolves dome-light poleAxis="scene".
+//   exposure/tonemap: applied by hdanari to the color AOV, not forwarded.
 // clang-format off
 #define HDANARI_RENDER_SETTINGS_TOKENS                                         \
-  (ambientColor) \
-  (ambientRadiance) \
-  (ambientSamples) \
-  (debugMethod) \
-  (denoise) \
-  (maxRayDepth) \
   (exposure) \
-  (pixelSamples) \
   (renderSubtype) \
-  (sampleLimit) \
   (tonemap) \
   (upAxis)
 // clang-format on
@@ -53,6 +52,14 @@ class HdAnariRenderDelegate final : public HdRenderDelegate
   HdResourceRegistrySharedPtr GetResourceRegistry() const override;
 
   HdRenderSettingDescriptorList GetRenderSettingDescriptors() const override;
+
+  // Renderer parameters discovered for the active subtype, consumed by the
+  // render pass to forward host render settings to the ANARI renderer.
+  const HdAnariRendererParamList &GetRendererParameters() const;
+
+  // Re-query parameters and rebuild the render-setting descriptors when the
+  // render pass switches the active renderer subtype. No-op if unchanged.
+  void SyncActiveRendererSubtype(const std::string &subtype);
 
   bool IsPauseSupported() const override;
   bool Pause() override;
@@ -106,9 +113,21 @@ class HdAnariRenderDelegate final : public HdRenderDelegate
   // Must outlive the device, so it is unloaded in the destructor after
   // _renderParam.
   anari::Library _library{nullptr};
+
+  // Re-query the subtype's parameters and rebuild _settingDescriptors. Caller
+  // must hold _settingsMutex.
+  void _SetActiveRendererSubtypeLocked(
+      anari::Device device, const std::string &subtype);
+  void _BuildSettingDescriptorsLocked();
+
   std::shared_ptr<HdAnariRenderParam> _renderParam;
 
+  // Guards _settingDescriptors / _rendererParams / _activeRendererSubtype,
+  // which the render thread rebuilds while the host reads descriptors.
+  mutable std::mutex _settingsMutex;
   HdRenderSettingDescriptorList _settingDescriptors;
+  HdAnariRendererParamList _rendererParams;
+  std::string _activeRendererSubtype;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/renderParam.h
+++ b/src/hdanari/rd/renderParam.h
@@ -69,6 +69,12 @@ class HdAnariRenderParam final : public HdRenderParam
   int SceneVersion() const;
   void MarkNewSceneVersion();
 
+  // Accumulation progress, published by the render pass and read back by the
+  // render delegate's GetRenderStats().
+  void SetProgress(int completedSamples, int sampleLimit);
+  int CompletedSamples() const;
+  int SampleLimit() const;
+
  private:
   anari::Device _device{nullptr};
   anari::Material _material{nullptr};
@@ -79,6 +85,8 @@ class HdAnariRenderParam final : public HdRenderParam
   GeometryList _geometries;
   LightList _lights;
   std::atomic<int> _sceneVersion{0};
+  std::atomic<int> _completedSamples{0};
+  std::atomic<int> _sampleLimit{0};
 };
 
 // Inlined definitions ////////////////////////////////////////////////////////
@@ -174,6 +182,23 @@ inline int HdAnariRenderParam::SceneVersion() const
 inline void HdAnariRenderParam::MarkNewSceneVersion()
 {
   _sceneVersion++;
+}
+
+inline void HdAnariRenderParam::SetProgress(
+    int completedSamples, int sampleLimit)
+{
+  _completedSamples.store(completedSamples);
+  _sampleLimit.store(sampleLimit);
+}
+
+inline int HdAnariRenderParam::CompletedSamples() const
+{
+  return _completedSamples.load();
+}
+
+inline int HdAnariRenderParam::SampleLimit() const
+{
+  return _sampleLimit.load();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/renderParam.h
+++ b/src/hdanari/rd/renderParam.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include "anariTypes.h"
 #include "debugCodes.h"
 #include "geometry.h"
-#include "anariTypes.h"
 #include "light.h"
 #include "material.h"
 #include "materialTokens.h"
@@ -31,7 +31,10 @@
 #include <anari/anari_cpp/anari_cpp_impl.hpp>
 #include <atomic>
 #include <cassert>
+#include <functional>
 #include <mutex>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -46,7 +49,8 @@ class HdAnariRenderParam final : public HdRenderParam
 {
  public:
   HdAnariRenderParam(anari::Device device,
-      HdAnariMaterial::MaterialType materialType = HdAnariMaterial::MaterialType::PhysicallyBased);
+      HdAnariMaterial::MaterialType materialType =
+          HdAnariMaterial::MaterialType::PhysicallyBased);
   ~HdAnariRenderParam() override;
 
   anari::Device GetANARIDevice() const;
@@ -75,11 +79,28 @@ class HdAnariRenderParam final : public HdRenderParam
   int CompletedSamples() const;
   int SampleLimit() const;
 
+  // Share one anari material across instances whose content (MDL source +
+  // parameters) is identical, so the device only compiles it and loads its
+  // textures once. `key` identifies the content; `create` builds the material
+  // on the first request. Balanced by ReleaseMdlMaterial.
+  anari::Material AcquireMdlMaterial(
+      const std::string &key, const std::function<anari::Material()> &create);
+  void ReleaseMdlMaterial(const std::string &key);
+
  private:
   anari::Device _device{nullptr};
   anari::Material _material{nullptr};
-  HdAnariMaterial::MaterialType _materialType{HdAnariMaterial::MaterialType::Matte};
+  HdAnariMaterial::MaterialType _materialType{
+      HdAnariMaterial::MaterialType::Matte};
   HdAnariMaterial::PrimvarBinding _primvarBinding;
+
+  struct MdlMaterialCacheEntry
+  {
+    anari::Material material;
+    int refCount;
+  };
+  std::mutex _mdlMaterialMutex;
+  std::unordered_map<std::string, MdlMaterialCacheEntry> _mdlMaterialCache;
 
   std::mutex _mutex;
   GeometryList _geometries;
@@ -113,9 +134,40 @@ inline HdAnariRenderParam::~HdAnariRenderParam()
   if (!_device)
     return;
 
+  for (auto &entry : _mdlMaterialCache)
+    anari::release(_device, entry.second.material);
+  _mdlMaterialCache.clear();
+
   anari::release(_device, _material);
   anari::release(_device, _device);
   _device = nullptr;
+}
+
+inline anari::Material HdAnariRenderParam::AcquireMdlMaterial(
+    const std::string &key, const std::function<anari::Material()> &create)
+{
+  std::lock_guard<std::mutex> guard(_mdlMaterialMutex);
+  auto it = _mdlMaterialCache.find(key);
+  if (it == cend(_mdlMaterialCache)) {
+    auto material = create();
+    if (!material)
+      return nullptr; // don't cache a failed creation and poison this key
+    it = _mdlMaterialCache.insert({key, {material, 0}}).first;
+  }
+  ++it->second.refCount;
+  return it->second.material;
+}
+
+inline void HdAnariRenderParam::ReleaseMdlMaterial(const std::string &key)
+{
+  std::lock_guard<std::mutex> guard(_mdlMaterialMutex);
+  auto it = _mdlMaterialCache.find(key);
+  if (it == cend(_mdlMaterialCache) || it->second.refCount == 0)
+    return;
+  if (--it->second.refCount == 0) {
+    anari::release(_device, it->second.material);
+    _mdlMaterialCache.erase(it);
+  }
 }
 
 inline anari::Device HdAnariRenderParam::GetANARIDevice() const

--- a/src/hdanari/rd/renderParam.h
+++ b/src/hdanari/rd/renderParam.h
@@ -119,11 +119,13 @@ inline HdAnariRenderParam::HdAnariRenderParam(
   if (!d)
     return;
 
-  // Always go with white matte as a fallback material.
+  // Fallback matte that samples the geometry's "color" attribute rather than a
+  // constant, so material-less geometry honors per-vertex displayColor. The
+  // geometry side writes that attribute: the authored displayColor array when
+  // present, or a constant fallback when absent (see HdAnariGeometry sync).
   _material = anari::newObject<anari::Material>(d, "matte");
   anari::setParameter(d, _material, "alphaMode", "opaque");
-  anari::setParameter(
-      d, _material, "color", GfVec3f(0.8f, 0.8f, 0.8f)); // "color");
+  anari::setParameter(d, _material, "color", "color");
   anari::commitParameters(d, _material);
 
   _primvarBinding.emplace(HdTokens->displayColor, "color");

--- a/src/hdanari/rd/renderPass.cpp
+++ b/src/hdanari/rd/renderPass.cpp
@@ -336,22 +336,26 @@ bool HdAnariRenderPass::_UpdateWorld()
   return true;
 }
 
-bool HdAnariRenderPass::_FrameIsConverged() const
+bool HdAnariRenderPass::_UpdateProgress()
 {
   auto d = _renderParam->GetANARIDevice();
 
-  // Devices that don't report sample progress render a complete frame in a
-  // single pass, so a finished frame is already converged.
   int numSamples = 0;
-  if (!anari::getProperty(
-          d, _anari.frame, "numSamples", numSamples, ANARI_WAIT))
-    return true;
+  const bool hasNumSamples = anari::getProperty(
+      d, _anari.frame, "numSamples", numSamples, ANARI_WAIT);
 
   HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
   const VtValue sp = renderDelegate->GetRenderSetting(
       HdAnariRenderSettingsTokens->sampleLimit);
   const int sampleLimit = sp.IsHolding<int>() ? sp.UncheckedGet<int>() : 0;
 
+  // Devices that don't report sample progress render a complete frame in a
+  // single pass, so a finished frame is already fully converged.
+  const int completedSamples = hasNumSamples ? numSamples : sampleLimit;
+  _renderParam->SetProgress(completedSamples, sampleLimit);
+
+  if (!hasNumSamples)
+    return true;
   return sampleLimit > 0 && numSamples >= sampleLimit;
 }
 
@@ -369,7 +373,7 @@ void HdAnariRenderPass::_WriteAovs(
 
   // A scene change this frame restarted accumulation, so report progress as
   // unconverged regardless of the (now stale) sample count.
-  const bool converged = !sceneChanged && _FrameIsConverged();
+  const bool converged = !sceneChanged && _UpdateProgress();
   for (auto &aov : aovBindings) {
     static_cast<HdAnariRenderBuffer *>(aov.renderBuffer)
         ->SetConverged(converged);

--- a/src/hdanari/rd/renderPass.cpp
+++ b/src/hdanari/rd/renderPass.cpp
@@ -13,6 +13,7 @@
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/cameraUtil/framing.h>
+#include <pxr/imaging/hd/camera.h>
 #include <pxr/imaging/hd/debugCodes.h>
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <anari/anari_cpp.hpp>
@@ -126,6 +127,11 @@ void HdAnariRenderPass::_Execute(
     TfTokenVector const &renderTags)
 {
   if (_renderParam) {
+    // UsdGeomCamera exposure travels with the scene; fold its linear scale in
+    // alongside the 'exposure' render setting. Defaults to 1 (neutral).
+    if (const HdCamera *camera = renderPassState->GetCamera())
+      _cameraExposureScale = camera->GetLinearExposureScale();
+
     bool sceneChanged = false;
     sceneChanged |= _UpdateFrame(
         _GetDataWindow(renderPassState), renderPassState->GetAovBindings());
@@ -219,6 +225,20 @@ bool HdAnariRenderPass::_UpdateRenderer()
           _anari.renderer,
           "method",
           debugMethod.UncheckedGet<std::string>().c_str());
+    }
+
+    // Exposure and tonemapping are applied by hdanari to the color AOV, not
+    // by the ANARI renderer, so these are read but not forwarded to the device.
+    if (const auto exposure = renderDelegate->GetRenderSetting(
+        HdAnariRenderSettingsTokens->exposure);
+        exposure.CanCast<float>()) {
+      _exposure = VtValue::Cast<float>(exposure).UncheckedGet<float>();
+    }
+
+    if (const auto tonemap = renderDelegate->GetRenderSetting(
+        HdAnariRenderSettingsTokens->tonemap);
+        tonemap.IsHolding<bool>()) {
+      _tonemap = tonemap.UncheckedGet<bool>();
     }
 
     anari::commitParameters(d, _anari.renderer);
@@ -366,9 +386,11 @@ void HdAnariRenderPass::_WriteAovs(
   if (!anari::isReady(d, _anari.frame))
     return;
 
+  const float exposureScale = std::exp2(_exposure) * _cameraExposureScale;
   for (auto &aov : aovBindings) {
     auto *b = (HdAnariRenderBuffer *)aov.renderBuffer;
-    b->CopyFromAnariFrame(d, _anari.frame, aov.aovName, aov.clearValue);
+    b->CopyFromAnariFrame(
+        d, _anari.frame, aov.aovName, aov.clearValue, exposureScale, _tonemap);
   }
 
   // A scene change this frame restarted accumulation, so report progress as

--- a/src/hdanari/rd/renderPass.cpp
+++ b/src/hdanari/rd/renderPass.cpp
@@ -14,7 +14,9 @@
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/cameraUtil/framing.h>
 #include <pxr/imaging/hd/camera.h>
+#include <pxr/imaging/hd/changeTracker.h>
 #include <pxr/imaging/hd/debugCodes.h>
+#include <pxr/imaging/hd/light.h>
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <anari/anari_cpp.hpp>
 #include <anari/anari_cpp/anari_cpp_impl.hpp>
@@ -131,6 +133,8 @@ void HdAnariRenderPass::_Execute(
     // alongside the 'exposure' render setting. Defaults to 1 (neutral).
     if (const HdCamera *camera = renderPassState->GetCamera())
       _cameraExposureScale = camera->GetLinearExposureScale();
+
+    _SyncDomeUpAxis();
 
     bool sceneChanged = false;
     sceneChanged |= _UpdateFrame(
@@ -326,6 +330,34 @@ bool HdAnariRenderPass::_UpdateCamera(
   }
 
   return true;
+}
+
+void HdAnariRenderPass::_SyncDomeUpAxis()
+{
+  HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
+  const VtValue v =
+      renderDelegate->GetRenderSetting(HdAnariRenderSettingsTokens->upAxis);
+  TfToken upAxis;
+  if (v.IsHolding<TfToken>())
+    upAxis = v.UncheckedGet<TfToken>();
+  else if (v.IsHolding<std::string>())
+    upAxis = TfToken(v.UncheckedGet<std::string>());
+
+  if (upAxis == _lastUpAxis)
+    return;
+
+  // The first observation just records the baseline: dome lights read the same
+  // setting on their initial sync, so there is nothing stale to invalidate yet.
+  const bool firstObservation = _lastUpAxis.IsEmpty();
+  _lastUpAxis = upAxis;
+  if (firstObservation)
+    return;
+
+  HdChangeTracker &tracker = GetRenderIndex()->GetChangeTracker();
+  for (const auto *light : _renderParam->Lights()) {
+    if (light->GetLightType() == HdPrimTypeTokens->domeLight)
+      tracker.MarkSprimDirty(light->GetId(), HdLight::DirtyParams);
+  }
 }
 
 bool HdAnariRenderPass::_UpdateWorld()

--- a/src/hdanari/rd/renderPass.cpp
+++ b/src/hdanari/rd/renderPass.cpp
@@ -149,106 +149,72 @@ void HdAnariRenderPass::_Execute(
 
 bool HdAnariRenderPass::_UpdateRenderer()
 {
-  HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
+  auto *renderDelegate = static_cast<HdAnariRenderDelegate *>(
+      GetRenderIndex()->GetRenderDelegate());
   int currentSettingsVersion = renderDelegate->GetRenderSettingsVersion();
   if (_lastSettingsVersion == currentSettingsVersion)
     return false;
 
-  {
-    auto d = _renderParam->GetANARIDevice();
+  auto d = _renderParam->GetANARIDevice();
 
-    if (const auto renderSubtype = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->renderSubtype);
-        TF_VERIFY(renderSubtype.IsHolding<std::string>())) {
-      if (_anari.renderer) {
-        anari::release(d, _anari.renderer);
-        anari::commitParameters(d, d);
-      }
-      _anari.renderer = anari::newObject<anari::Renderer>(
-          d, renderSubtype.UncheckedGet<std::string>().c_str());
-      anari::setParameter(d, _anari.frame, "renderer", _anari.renderer);
-      anari::commitParameters(d, _anari.frame);
-    }
+  std::string subtype = "default";
+  if (const auto rs = renderDelegate->GetRenderSetting(
+          HdAnariRenderSettingsTokens->renderSubtype);
+      rs.IsHolding<std::string>() && !rs.UncheckedGet<std::string>().empty())
+    subtype = rs.UncheckedGet<std::string>();
+  else if (rs.IsHolding<TfToken>() && !rs.UncheckedGet<TfToken>().IsEmpty())
+    subtype = rs.UncheckedGet<TfToken>().GetString();
 
-    if (const VtValue ar = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->ambientRadiance);
-        TF_VERIFY(ar.CanCast<float>())) {
-      auto v = VtValue::Cast<float>(ar).UncheckedGet<float>();
-      anari::setParameter(d,
-          _anari.renderer,
-          "ambientRadiance",
-          VtValue::Cast<float>(ar).UncheckedGet<float>());
-    }
-
-    if (const auto ac = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->ambientColor);
-        TF_VERIFY(ac.IsHolding<GfVec3f>())) {
-      anari::setParameter(
-          d, _anari.renderer, "ambientColor", ac.UncheckedGet<GfVec3f>());
-    }
-
-    if (const auto as = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->ambientSamples);
-        TF_VERIFY(as.IsHolding<int>())) {
-      anari::setParameter(
-          d, _anari.renderer, "ambientSamples", as.UncheckedGet<int>());
-    }
-
-    if (const auto sp = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->sampleLimit);
-        TF_VERIFY(sp.IsHolding<int>())) {
-      anari::setParameter(
-          d, _anari.renderer, "sampleLimit", sp.UncheckedGet<int>());
-    }
-
-    if (const auto rb = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->maxRayDepth);
-        TF_VERIFY(rb.IsHolding<int>())) {
-      anari::setParameter(
-          d, _anari.renderer, "maxRayDepth", rb.UncheckedGet<int>());
-    }
-
-    if (const auto ps = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->pixelSamples);
-        TF_VERIFY(ps.IsHolding<int>())) {
-      anari::setParameter(
-          d, _anari.renderer, "pixelSamples", ps.UncheckedGet<int>());
-    }
-
-    if (const auto denoise =
-        renderDelegate->GetRenderSetting(HdAnariRenderSettingsTokens->denoise);
-        TF_VERIFY(denoise.IsHolding<bool>())) {
-      anari::setParameter(
-          d, _anari.renderer, "denoise", denoise.UncheckedGet<bool>());
-    }
-
-    if (const auto debugMethod = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->debugMethod);
-        debugMethod.IsHolding<std::string>()) {
-      anari::setParameter(d,
-          _anari.renderer,
-          "method",
-          debugMethod.UncheckedGet<std::string>().c_str());
-    }
-
-    // Exposure and tonemapping are applied by hdanari to the color AOV, not
-    // by the ANARI renderer, so these are read but not forwarded to the device.
-    if (const auto exposure = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->exposure);
-        exposure.CanCast<float>()) {
-      _exposure = VtValue::Cast<float>(exposure).UncheckedGet<float>();
-    }
-
-    if (const auto tonemap = renderDelegate->GetRenderSetting(
-        HdAnariRenderSettingsTokens->tonemap);
-        tonemap.IsHolding<bool>()) {
-      _tonemap = tonemap.UncheckedGet<bool>();
-    }
-
-    anari::commitParameters(d, _anari.renderer);
-
-    _lastSettingsVersion = currentSettingsVersion;
+  // (Re)create the renderer on first use or whenever the subtype changes; this
+  // also re-derives the parameter set advertised for that subtype.
+  if (!_anari.renderer || subtype != _rendererSubtype) {
+    if (_anari.renderer)
+      anari::release(d, _anari.renderer);
+    _rendererSubtype = subtype;
+    renderDelegate->SyncActiveRendererSubtype(subtype);
+    _anari.renderer = anari::newObject<anari::Renderer>(d, subtype.c_str());
+    anari::setParameter(d, _anari.frame, "renderer", _anari.renderer);
+    anari::commitParameters(d, _anari.frame);
+    // background is driven from the Hydra color AOV clear value; re-apply it so
+    // the freshly created renderer keeps the current clear color.
+    anari::setParameter(d, _anari.renderer, "background", _clearColor);
   }
+
+  // Forward every host setting that maps to an introspected renderer parameter.
+  for (const auto &param : renderDelegate->GetRendererParameters()) {
+    const auto value = renderDelegate->GetRenderSetting(param.key);
+    if (value.IsEmpty())
+      continue;
+    // Don't forward a fabricated default (the device advertised none) the user
+    // hasn't overridden -- it would clobber the renderer's own implicit default.
+    if (!param.hasDeviceDefault && value == param.defaultValue)
+      continue;
+    if (!HdAnariSetRendererParameter(d, _anari.renderer, param, value)) {
+      TF_WARN(
+          "hdAnari: render setting '%s' could not be forwarded to ANARI "
+          "renderer parameter of type %s",
+          param.name.c_str(),
+          anari::toString(param.type));
+    }
+  }
+
+  // Exposure and tonemapping are applied by hdanari to the color AOV, not by
+  // the ANARI renderer, so these are read but not forwarded to the device.
+  if (const auto exposure = renderDelegate->GetRenderSetting(
+          HdAnariRenderSettingsTokens->exposure);
+      exposure.CanCast<float>()) {
+    _exposure = VtValue::Cast<float>(exposure).UncheckedGet<float>();
+  }
+
+  if (const auto tonemap = renderDelegate->GetRenderSetting(
+          HdAnariRenderSettingsTokens->tonemap);
+      tonemap.IsHolding<bool>()) {
+    _tonemap = tonemap.UncheckedGet<bool>();
+  }
+
+  anari::commitParameters(d, _anari.renderer);
+
+  _lastSettingsVersion = currentSettingsVersion;
 
   return true;
 }
@@ -393,22 +359,39 @@ bool HdAnariRenderPass::_UpdateProgress()
   auto d = _renderParam->GetANARIDevice();
 
   int numSamples = 0;
-  const bool hasNumSamples = anari::getProperty(
-      d, _anari.frame, "numSamples", numSamples, ANARI_WAIT);
+  const bool hasNumSamples =
+      anari::getProperty(d, _anari.frame, "numSamples", numSamples, ANARI_WAIT);
 
+  // The accumulation bound is the renderer's introspected "sampleLimit"
+  // parameter, when it advertises one.
+  static const TfToken sampleLimitToken("sampleLimit");
   HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
-  const VtValue sp = renderDelegate->GetRenderSetting(
-      HdAnariRenderSettingsTokens->sampleLimit);
-  const int sampleLimit = sp.IsHolding<int>() ? sp.UncheckedGet<int>() : 0;
+  const VtValue sp = renderDelegate->GetRenderSetting(sampleLimitToken);
+  // When the active renderer advertises no sampleLimit (e.g. VisRTX's "default"
+  // renderer exposes none), fall back to a finite host-side bound so batch
+  // renders (usdrecord) converge instead of accumulating forever. A renderer
+  // that DOES expose sampleLimit but is explicitly set to 0 still means
+  // "unbounded" and keeps refining (interactive viewers). Cast rather than
+  // IsHolding<int> so an int32/uint32/int64-typed parameter is honored, not
+  // silently treated as the fallback.
+  static constexpr int kFallbackSampleLimit = 128;
+  const int sampleLimit = sp.CanCast<int>()
+      ? VtValue::Cast<int>(sp).UncheckedGet<int>()
+      : kFallbackSampleLimit;
 
   // Devices that don't report sample progress render a complete frame in a
   // single pass, so a finished frame is already fully converged.
   const int completedSamples = hasNumSamples ? numSamples : sampleLimit;
   _renderParam->SetProgress(completedSamples, sampleLimit);
 
+  // No per-sample progress reported: a finished frame is fully converged.
   if (!hasNumSamples)
     return true;
-  return sampleLimit > 0 && numSamples >= sampleLimit;
+  // An explicit sampleLimit of 0 means "unbounded": keep refining (the fallback
+  // above only applies when the renderer advertises no sampleLimit at all).
+  if (sampleLimit <= 0)
+    return false;
+  return numSamples >= sampleLimit;
 }
 
 void HdAnariRenderPass::_WriteAovs(

--- a/src/hdanari/rd/renderPass.cpp
+++ b/src/hdanari/rd/renderPass.cpp
@@ -126,21 +126,25 @@ void HdAnariRenderPass::_Execute(
     TfTokenVector const &renderTags)
 {
   if (_renderParam) {
-    _UpdateFrame(
+    bool sceneChanged = false;
+    sceneChanged |= _UpdateFrame(
         _GetDataWindow(renderPassState), renderPassState->GetAovBindings());
-    _UpdateRenderer();
-    _UpdateCamera(renderPassState->GetWorldToViewMatrix(),
+    sceneChanged |= _UpdateRenderer();
+    sceneChanged |= _UpdateCamera(renderPassState->GetWorldToViewMatrix(),
         renderPassState->GetProjectionMatrix());
-    _UpdateWorld();
-    _WriteAovs(renderPassState->GetAovBindings());
+    sceneChanged |= _UpdateWorld();
+    _WriteAovs(renderPassState->GetAovBindings(), sceneChanged);
   }
 }
 
-void HdAnariRenderPass::_UpdateRenderer()
+bool HdAnariRenderPass::_UpdateRenderer()
 {
   HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
   int currentSettingsVersion = renderDelegate->GetRenderSettingsVersion();
-  if (_lastSettingsVersion != currentSettingsVersion) {
+  if (_lastSettingsVersion == currentSettingsVersion)
+    return false;
+
+  {
     auto d = _renderParam->GetANARIDevice();
 
     if (const auto renderSubtype = renderDelegate->GetRenderSetting(
@@ -221,12 +225,15 @@ void HdAnariRenderPass::_UpdateRenderer()
 
     _lastSettingsVersion = currentSettingsVersion;
   }
+
+  return true;
 }
 
-void HdAnariRenderPass::_UpdateFrame(
+bool HdAnariRenderPass::_UpdateFrame(
     const GfRect2i &size, const HdRenderPassAovBindingVector &aovBindings)
 {
   auto d = _renderParam->GetANARIDevice();
+  bool changed = false;
 
   if (_frameSize != size) {
     _frameSize = size;
@@ -234,6 +241,7 @@ void HdAnariRenderPass::_UpdateFrame(
         (uint32_t)size.GetWidth(), (uint32_t)size.GetHeight()};
     anari::setParameter(d, _anari.frame, "size", s);
     anari::commitParameters(d, _anari.frame);
+    changed = true;
   }
 
   bool aovDirty = (_aovBindings.empty() || _aovBindings != aovBindings);
@@ -251,18 +259,24 @@ void HdAnariRenderPass::_UpdateFrame(
         _clearColor = clearColor;
         anari::setParameter(d, _anari.renderer, "background", _clearColor);
         anari::commitParameters(d, _anari.renderer);
+        changed = true;
       }
       break;
     }
   }
+
+  return changed;
 }
 
-void HdAnariRenderPass::_UpdateCamera(
+bool HdAnariRenderPass::_UpdateCamera(
     const GfMatrix4d &view, const GfMatrix4d &proj)
 {
   auto d = _renderParam->GetANARIDevice();
 
-  if (_camera.view != view || _camera.proj != proj) {
+  if (_camera.view == view && _camera.proj == proj)
+    return false;
+
+  {
     _camera.view = view;
     _camera.proj = proj;
     _camera.invView = view.GetInverse();
@@ -290,13 +304,15 @@ void HdAnariRenderPass::_UpdateCamera(
 
     anari::commitParameters(d, _anari.camera);
   }
+
+  return true;
 }
 
-void HdAnariRenderPass::_UpdateWorld()
+bool HdAnariRenderPass::_UpdateWorld()
 {
   auto sceneVersion = _renderParam->SceneVersion();
   if (sceneVersion <= _lastSceneVersion)
-    return;
+    return false;
 
   std::vector<anari::Instance> instances;
 
@@ -316,10 +332,31 @@ void HdAnariRenderPass::_UpdateWorld()
   anari::commitParameters(d, _anari.world);
 
   _lastSceneVersion = sceneVersion;
+
+  return true;
+}
+
+bool HdAnariRenderPass::_FrameIsConverged() const
+{
+  auto d = _renderParam->GetANARIDevice();
+
+  // Devices that don't report sample progress render a complete frame in a
+  // single pass, so a finished frame is already converged.
+  int numSamples = 0;
+  if (!anari::getProperty(
+          d, _anari.frame, "numSamples", numSamples, ANARI_WAIT))
+    return true;
+
+  HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
+  const VtValue sp = renderDelegate->GetRenderSetting(
+      HdAnariRenderSettingsTokens->sampleLimit);
+  const int sampleLimit = sp.IsHolding<int>() ? sp.UncheckedGet<int>() : 0;
+
+  return sampleLimit > 0 && numSamples >= sampleLimit;
 }
 
 void HdAnariRenderPass::_WriteAovs(
-    const HdRenderPassAovBindingVector &aovBindings)
+    const HdRenderPassAovBindingVector &aovBindings, bool sceneChanged)
 {
   auto d = _renderParam->GetANARIDevice();
   if (!anari::isReady(d, _anari.frame))
@@ -330,7 +367,18 @@ void HdAnariRenderPass::_WriteAovs(
     b->CopyFromAnariFrame(d, _anari.frame, aov.aovName, aov.clearValue);
   }
 
-  anari::render(d, _anari.frame);
+  // A scene change this frame restarted accumulation, so report progress as
+  // unconverged regardless of the (now stale) sample count.
+  const bool converged = !sceneChanged && _FrameIsConverged();
+  for (auto &aov : aovBindings) {
+    static_cast<HdAnariRenderBuffer *>(aov.renderBuffer)
+        ->SetConverged(converged);
+  }
+
+  // Kick the next accumulation pass only while there is more work to do;
+  // re-rendering a converged frame would never let usdrecord terminate.
+  if (!converged)
+    anari::render(d, _anari.frame);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/renderPass.h
+++ b/src/hdanari/rd/renderPass.h
@@ -64,6 +64,9 @@ struct HdAnariRenderPass final : public HdRenderPass
 
   int _lastSettingsVersion{-1};
   int _lastSceneVersion{-1};
+  float _exposure{0.0f};
+  float _cameraExposureScale{1.0f};
+  bool _tonemap{false};
 
   struct AnariObjects
   {

--- a/src/hdanari/rd/renderPass.h
+++ b/src/hdanari/rd/renderPass.h
@@ -17,6 +17,7 @@
 #include <pxr/pxr.h>
 
 #include <memory>
+#include <string>
 
 #include "renderParam.h"
 
@@ -69,6 +70,9 @@ struct HdAnariRenderPass final : public HdRenderPass
 
   int _lastSettingsVersion{-1};
   int _lastSceneVersion{-1};
+  // Active ANARI renderer subtype; a change triggers renderer recreation and
+  // re-derivation of the forwarded parameter set.
+  std::string _rendererSubtype;
   TfToken _lastUpAxis;
   float _exposure{0.0f};
   float _cameraExposureScale{1.0f};

--- a/src/hdanari/rd/renderPass.h
+++ b/src/hdanari/rd/renderPass.h
@@ -40,7 +40,9 @@ struct HdAnariRenderPass final : public HdRenderPass
       const GfRect2i &size, const HdRenderPassAovBindingVector &aovBindings);
   bool _UpdateCamera(const GfMatrix4d &invView, const GfMatrix4d &invProj);
   bool _UpdateWorld();
-  bool _FrameIsConverged() const;
+  // Publishes accumulation progress to the render param and returns whether
+  // the frame has reached its sample limit.
+  bool _UpdateProgress();
   void _WriteAovs(
       const HdRenderPassAovBindingVector &aovBindings, bool sceneChanged);
 

--- a/src/hdanari/rd/renderPass.h
+++ b/src/hdanari/rd/renderPass.h
@@ -40,6 +40,11 @@ struct HdAnariRenderPass final : public HdRenderPass
       const GfRect2i &size, const HdRenderPassAovBindingVector &aovBindings);
   bool _UpdateCamera(const GfMatrix4d &invView, const GfMatrix4d &invProj);
   bool _UpdateWorld();
+  // A render-settings change (e.g. the host re-reporting the stage up axis)
+  // doesn't dirty Sprims, so dome lights whose poleAxis resolves to "scene"
+  // would keep a stale orientation. Detect upAxis changes and force the domes
+  // to re-sync.
+  void _SyncDomeUpAxis();
   // Publishes accumulation progress to the render param and returns whether
   // the frame has reached its sample limit.
   bool _UpdateProgress();
@@ -64,6 +69,7 @@ struct HdAnariRenderPass final : public HdRenderPass
 
   int _lastSettingsVersion{-1};
   int _lastSceneVersion{-1};
+  TfToken _lastUpAxis;
   float _exposure{0.0f};
   float _cameraExposureScale{1.0f};
   bool _tonemap{false};

--- a/src/hdanari/rd/renderPass.h
+++ b/src/hdanari/rd/renderPass.h
@@ -33,12 +33,16 @@ struct HdAnariRenderPass final : public HdRenderPass
       TfTokenVector const &renderTags) override;
 
  private:
-  void _UpdateRenderer();
-  void _UpdateFrame(
+  // The _Update* helpers return true when they change ANARI state, which
+  // resets the device's sample accumulation and thus restarts convergence.
+  bool _UpdateRenderer();
+  bool _UpdateFrame(
       const GfRect2i &size, const HdRenderPassAovBindingVector &aovBindings);
-  void _UpdateCamera(const GfMatrix4d &invView, const GfMatrix4d &invProj);
-  void _UpdateWorld();
-  void _WriteAovs(const HdRenderPassAovBindingVector &aovBindings);
+  bool _UpdateCamera(const GfMatrix4d &invView, const GfMatrix4d &invProj);
+  bool _UpdateWorld();
+  bool _FrameIsConverged() const;
+  void _WriteAovs(
+      const HdRenderPassAovBindingVector &aovBindings, bool sceneChanged);
 
   std::shared_ptr<HdAnariRenderParam> _renderParam;
 

--- a/src/hdanari/rd/renderSettings.cpp
+++ b/src/hdanari/rd/renderSettings.cpp
@@ -1,0 +1,71 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "renderSettings.h"
+#include "renderDelegate.h"
+
+#include <cstring>
+
+#include <pxr/base/tf/stringUtils.h>
+#include <pxr/imaging/hd/dataSource.h>
+#include <pxr/imaging/hd/renderIndex.h>
+#include <pxr/imaging/hd/renderSettingsSchema.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+#include <pxr/imaging/hd/sceneIndex.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+// Render settings authored on a UsdRenderSettings prim are surfaced by USD only
+// when namespaced; hdAnari collects the "anari:" ones (see
+// GetRenderSettingsNamespaces) and strips the prefix to the plain setting token
+// (`anari:renderSubtype` -> `renderSubtype`).
+constexpr const char *kNamespacePrefix = "anari:";
+} // namespace
+
+HdAnariRenderSettings::HdAnariRenderSettings(SdfPath const &id)
+    : HdRenderSettings(id)
+{}
+
+HdAnariRenderSettings::~HdAnariRenderSettings() = default;
+
+void HdAnariRenderSettings::_Sync(HdSceneDelegate *sceneDelegate,
+    HdRenderParam *renderParam,
+    const HdDirtyBits *dirtyBits)
+{
+  // The legacy scene-delegate path leaves the base class's namespaced settings
+  // empty, so read them from the terminal scene index directly and route them
+  // into the delegate's setting map that the render pass reads via
+  // GetRenderSetting().
+  auto &renderIndex = sceneDelegate->GetRenderIndex();
+  auto si = renderIndex.GetTerminalSceneIndex();
+  if (!si)
+    return;
+
+  const HdSceneIndexPrim prim = si->GetPrim(GetId());
+  HdRenderSettingsSchema rs =
+      HdRenderSettingsSchema::GetFromParent(prim.dataSource);
+  if (!rs)
+    return;
+
+  const HdContainerDataSourceHandle settings =
+      rs.GetNamespacedSettings().GetContainer();
+  if (!settings)
+    return;
+
+  auto *renderDelegate =
+      static_cast<HdAnariRenderDelegate *>(renderIndex.GetRenderDelegate());
+
+  for (const TfToken &name : settings->GetNames()) {
+    if (!TfStringStartsWith(name.GetString(), kNamespacePrefix))
+      continue;
+    auto ds = HdSampledDataSource::Cast(settings->Get(name));
+    if (!ds)
+      continue;
+    const std::string key =
+        name.GetString().substr(std::strlen(kNamespacePrefix));
+    renderDelegate->SetRenderSetting(TfToken(key), ds->GetValue(0.0f));
+  }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/renderSettings.h
+++ b/src/hdanari/rd/renderSettings.h
@@ -1,0 +1,32 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef HDANARI_RENDERSETTINGS_H
+#define HDANARI_RENDERSETTINGS_H
+
+#include <pxr/imaging/hd/renderSettings.h>
+#include <pxr/pxr.h>
+#include <pxr/usd/sdf/path.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// Bridges a UsdRenderSettings prim's namespaced settings into the render
+// delegate's setting map. Without this, scene-authored settings (renderSubtype
+// and every introspected renderer parameter) reach Hydra only as a
+// renderSettings Bprim, never the legacy GetRenderSetting() map the render pass
+// reads from, so `usdrecord --renderSettingsPrimPath` is silently ignored.
+class HdAnariRenderSettings final : public HdRenderSettings
+{
+ public:
+  explicit HdAnariRenderSettings(SdfPath const &id);
+  ~HdAnariRenderSettings() override;
+
+ protected:
+  void _Sync(HdSceneDelegate *sceneDelegate,
+      HdRenderParam *renderParam,
+      const HdDirtyBits *dirtyBits) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDANARI_RENDERSETTINGS_H

--- a/src/hdanari/rd/rendererParameters.cpp
+++ b/src/hdanari/rd/rendererParameters.cpp
@@ -1,0 +1,238 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "rendererParameters.h"
+
+// Provides the anari::ANARITypeFor<GfVec*> specializations that
+// anari::setParameter resolves implicitly below. // IWYU pragma: keep
+#include "anariTypes.h"
+
+#include <anari/anari.h>
+#include <anari/frontend/anari_enums.h>
+
+#include <pxr/base/gf/vec2f.h>
+#include <pxr/base/gf/vec2i.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec3i.h>
+#include <pxr/base/gf/vec4f.h>
+#include <pxr/base/gf/vec4i.h>
+
+#include <cstdint>
+#include <set>
+#include <string>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// Renderer parameters never auto-exposed nor auto-forwarded.
+//   background: driven from the Hydra color AOV clear value.
+//   name:       the generic ANARI object name, meaningless as a render setting.
+const std::set<std::string> kInternallyManagedParameters = {
+    "background",
+    "name",
+};
+
+// Map ANARI parameter memory into a VtValue of the matching USD type. Returns
+// an empty VtValue for types hdanari does not expose as render settings.
+VtValue AnariMemoryToVtValue(ANARIDataType type, const void *mem)
+{
+  if (!mem)
+    return {};
+
+  switch (type) {
+  case ANARI_BOOL:
+    return VtValue(*static_cast<const int8_t *>(mem) != 0);
+  case ANARI_INT32:
+    return VtValue(*static_cast<const int32_t *>(mem));
+  case ANARI_UINT32:
+    return VtValue(*static_cast<const uint32_t *>(mem));
+  case ANARI_FLOAT32:
+    return VtValue(*static_cast<const float *>(mem));
+  case ANARI_FLOAT64:
+    return VtValue(*static_cast<const double *>(mem));
+  case ANARI_FLOAT32_VEC2:
+    return VtValue(GfVec2f(static_cast<const float *>(mem)));
+  case ANARI_FLOAT32_VEC3:
+    return VtValue(GfVec3f(static_cast<const float *>(mem)));
+  case ANARI_FLOAT32_VEC4:
+    return VtValue(GfVec4f(static_cast<const float *>(mem)));
+  case ANARI_INT32_VEC2:
+    return VtValue(GfVec2i(static_cast<const int32_t *>(mem)));
+  case ANARI_INT32_VEC3:
+    return VtValue(GfVec3i(static_cast<const int32_t *>(mem)));
+  case ANARI_INT32_VEC4:
+    return VtValue(GfVec4i(static_cast<const int32_t *>(mem)));
+  case ANARI_STRING:
+    return VtValue(std::string(static_cast<const char *>(mem)));
+  default:
+    return {};
+  }
+}
+
+// A zero/empty VtValue of the USD type matching an ANARI type. Used as the
+// render-setting default when the device reports none. Empty result marks the
+// ANARI type as unsupported.
+VtValue ZeroVtValueForType(ANARIDataType type)
+{
+  switch (type) {
+  case ANARI_BOOL:
+    return VtValue(false);
+  case ANARI_INT32:
+    return VtValue(int32_t(0));
+  case ANARI_UINT32:
+    return VtValue(uint32_t(0));
+  case ANARI_FLOAT32:
+    return VtValue(0.0f);
+  case ANARI_FLOAT64:
+    return VtValue(0.0);
+  case ANARI_FLOAT32_VEC2:
+    return VtValue(GfVec2f(0.0f));
+  case ANARI_FLOAT32_VEC3:
+    return VtValue(GfVec3f(0.0f));
+  case ANARI_FLOAT32_VEC4:
+    return VtValue(GfVec4f(0.0f));
+  case ANARI_INT32_VEC2:
+    return VtValue(GfVec2i(0));
+  case ANARI_INT32_VEC3:
+    return VtValue(GfVec3i(0));
+  case ANARI_INT32_VEC4:
+    return VtValue(GfVec4i(0));
+  case ANARI_STRING:
+    return VtValue(std::string());
+  default:
+    return {};
+  }
+}
+
+const void *QueryParameterInfo(anari::Device d,
+    const char *subtype,
+    const ANARIParameter &param,
+    const char *infoName,
+    ANARIDataType infoType)
+{
+  return anariGetParameterInfo(
+      d, ANARI_RENDERER, subtype, param.name, param.type, infoName, infoType);
+}
+
+template <typename T>
+bool CastAndSet(anari::Device d,
+    anari::Renderer r,
+    const char *name,
+    const VtValue &value)
+{
+  const VtValue cast = VtValue::Cast<T>(value);
+  if (cast.IsEmpty())
+    return false;
+  anari::setParameter(d, r, name, cast.UncheckedGet<T>());
+  return true;
+}
+
+} // namespace
+
+HdAnariRendererParamList HdAnariQueryRendererParameters(
+    anari::Device device, const char *subtype)
+{
+  HdAnariRendererParamList retval;
+
+  const auto *params = static_cast<const ANARIParameter *>(anariGetObjectInfo(
+      device, ANARI_RENDERER, subtype, "parameter", ANARI_PARAMETER_LIST));
+
+  // A parameter name may be listed more than once with different ANARI types
+  // (e.g. VisRTX's vec4 vs. array2d "background"); keep the first mappable one.
+  std::set<std::string> seen;
+
+  for (; params && params->name != nullptr; ++params) {
+    if (kInternallyManagedParameters.count(params->name))
+      continue;
+    if (seen.count(params->name))
+      continue;
+
+    HdAnariRendererParam p;
+    p.name = params->name;
+    p.type = params->type;
+
+    // Skip parameters whose ANARI type has no VtValue mapping.
+    if (ZeroVtValueForType(params->type).IsEmpty())
+      continue;
+
+    const void *defaultMem =
+        QueryParameterInfo(device, subtype, *params, "default", params->type);
+    // When the device reports no default we fabricate a zero so the setting has
+    // a value, but flag it so it is not forwarded back over the device's own
+    // implicit default (see the forwarding loop in renderPass).
+    p.hasDeviceDefault = defaultMem != nullptr;
+    p.defaultValue = defaultMem ? AnariMemoryToVtValue(params->type, defaultMem)
+                                : ZeroVtValueForType(params->type);
+
+    p.key = TfToken(p.name);
+
+    if (const void *minMem = QueryParameterInfo(
+            device, subtype, *params, "minimum", params->type))
+      p.minValue = AnariMemoryToVtValue(params->type, minMem);
+    if (const void *maxMem = QueryParameterInfo(
+            device, subtype, *params, "maximum", params->type))
+      p.maxValue = AnariMemoryToVtValue(params->type, maxMem);
+
+    if (const auto *description = static_cast<const char *>(QueryParameterInfo(
+            device, subtype, *params, "description", ANARI_STRING)))
+      p.description = description;
+
+    const auto *const *values =
+        static_cast<const char *const *>(QueryParameterInfo(
+            device, subtype, *params, "value", ANARI_STRING_LIST));
+    for (; values && *values; ++values)
+      p.stringValues.emplace_back(*values);
+
+    seen.insert(p.name);
+    retval.push_back(std::move(p));
+  }
+
+  return retval;
+}
+
+bool HdAnariSetRendererParameter(anari::Device d,
+    anari::Renderer r,
+    const HdAnariRendererParam &param,
+    const VtValue &value)
+{
+  const char *name = param.name.c_str();
+  switch (param.type) {
+  case ANARI_BOOL:
+    return CastAndSet<bool>(d, r, name, value);
+  case ANARI_INT32:
+    return CastAndSet<int32_t>(d, r, name, value);
+  case ANARI_UINT32:
+    return CastAndSet<uint32_t>(d, r, name, value);
+  case ANARI_FLOAT32:
+    return CastAndSet<float>(d, r, name, value);
+  case ANARI_FLOAT64:
+    return CastAndSet<double>(d, r, name, value);
+  case ANARI_FLOAT32_VEC2:
+    return CastAndSet<GfVec2f>(d, r, name, value);
+  case ANARI_FLOAT32_VEC3:
+    return CastAndSet<GfVec3f>(d, r, name, value);
+  case ANARI_FLOAT32_VEC4:
+    return CastAndSet<GfVec4f>(d, r, name, value);
+  case ANARI_INT32_VEC2:
+    return CastAndSet<GfVec2i>(d, r, name, value);
+  case ANARI_INT32_VEC3:
+    return CastAndSet<GfVec3i>(d, r, name, value);
+  case ANARI_INT32_VEC4:
+    return CastAndSet<GfVec4i>(d, r, name, value);
+  case ANARI_STRING:
+    if (value.IsHolding<std::string>()) {
+      anari::setParameter(d, r, name, value.UncheckedGet<std::string>().c_str());
+      return true;
+    }
+    if (value.IsHolding<TfToken>()) {
+      anari::setParameter(d, r, name, value.UncheckedGet<TfToken>().GetText());
+      return true;
+    }
+    return false;
+  default:
+    return false;
+  }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/rendererParameters.h
+++ b/src/hdanari/rd/rendererParameters.h
@@ -1,0 +1,50 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <anari/anari_cpp.hpp>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/pxr.h>
+
+#include <string>
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// A single renderer parameter discovered through ANARI introspection
+// (anariGetObjectInfo / anariGetParameterInfo). Defaults and bounds are
+// resolved from the device, so the delegate never hardcodes them.
+struct HdAnariRendererParam
+{
+  std::string name; // verbatim ANARI parameter name
+  TfToken key; // == TfToken(name); the Hydra render-setting key
+  ANARIDataType type{ANARI_UNKNOWN};
+  VtValue defaultValue;
+  bool hasDeviceDefault{false}; // false when defaultValue is a fabricated zero
+  VtValue minValue; // empty when the device reports no minimum
+  VtValue maxValue; // empty when the device reports no maximum
+  std::string description;
+  // Valid values when this is a string-enum parameter, else empty.
+  std::vector<std::string> stringValues;
+};
+
+using HdAnariRendererParamList = std::vector<HdAnariRendererParam>;
+
+// Parameters of a renderer subtype, with defaults/bounds/descriptions resolved
+// from device introspection. Parameters whose ANARI type has no VtValue mapping
+// (objects, arrays, ...) and parameters hdanari drives internally are skipped.
+HdAnariRendererParamList HdAnariQueryRendererParameters(
+    anari::Device device, const char *subtype);
+
+// Forward a host-provided render-setting value to an ANARI renderer parameter,
+// casting the VtValue to the parameter's introspected ANARI type. Returns false
+// when the value cannot be represented as that type.
+bool HdAnariSetRendererParameter(anari::Device device,
+    anari::Renderer renderer,
+    const HdAnariRendererParam &param,
+    const VtValue &value);
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/subdivision.cpp
+++ b/src/hdanari/rd/subdivision.cpp
@@ -1,0 +1,193 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "subdivision.h"
+
+#include <pxr/base/gf/vec2f.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec4f.h>
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/types.h>
+#include <pxr/imaging/pxOsd/tokens.h>
+
+#include <opensubdiv/far/primvarRefiner.h>
+#include <opensubdiv/far/topologyRefiner.h>
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+namespace Far = OpenSubdiv::Far;
+
+// PrimvarRefiner element wrapper. T is float or a GfVec*f; both support the
+// scalar constructor (zero) and (vec * float) used here.
+template <typename T>
+struct _Element
+{
+  T value;
+  void Clear()
+  {
+    value = T(0.0f);
+  }
+  void AddWithWeight(const _Element &src, float weight)
+  {
+    value += src.value * weight;
+  }
+};
+
+enum class _Mode
+{
+  Vertex,
+  Varying,
+  Uniform
+};
+
+template <typename T>
+VtArray<T> _RefineArray(const Far::TopologyRefiner &refiner,
+    int level,
+    _Mode mode,
+    const VtArray<T> &coarse)
+{
+  Far::PrimvarRefiner primvarRefiner(refiner);
+
+  // Uniform primvars carry one value per face; everything else, one per vertex.
+  const bool perFace = mode == _Mode::Uniform;
+  const int total =
+      perFace ? refiner.GetNumFacesTotal() : refiner.GetNumVerticesTotal();
+
+  std::vector<_Element<T>> buffer(total);
+  for (size_t i = 0; i < coarse.size() && i < buffer.size(); ++i)
+    buffer[i].value = coarse[i];
+
+  _Element<T> *src = buffer.data();
+  for (int l = 1; l <= level; ++l) {
+    const Far::TopologyLevel &prev = refiner.GetLevel(l - 1);
+    _Element<T> *dst =
+        src + (perFace ? prev.GetNumFaces() : prev.GetNumVertices());
+    switch (mode) {
+    case _Mode::Vertex:
+      primvarRefiner.Interpolate(l, src, dst);
+      break;
+    case _Mode::Varying:
+      primvarRefiner.InterpolateVarying(l, src, dst);
+      break;
+    case _Mode::Uniform:
+      primvarRefiner.InterpolateFaceUniform(l, src, dst);
+      break;
+    }
+    src = dst;
+  }
+
+  const Far::TopologyLevel &last = refiner.GetLevel(level);
+  const int count = perFace ? last.GetNumFaces() : last.GetNumVertices();
+  VtArray<T> refined(count);
+  for (int i = 0; i < count; ++i)
+    refined[i] = src[i].value;
+  return refined;
+}
+
+VtValue _RefineTyped(const Far::TopologyRefiner &refiner,
+    int level,
+    _Mode mode,
+    const VtValue &v)
+{
+  if (v.IsHolding<VtVec3fArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtVec3fArray>()));
+  if (v.IsHolding<VtVec2fArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtVec2fArray>()));
+  if (v.IsHolding<VtVec4fArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtVec4fArray>()));
+  if (v.IsHolding<VtFloatArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtFloatArray>()));
+  // Double-precision variants: texcoords in particular can be authored double
+  // (see _FlipTextureCoordinateV), so refine them rather than drop.
+  if (v.IsHolding<VtVec3dArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtVec3dArray>()));
+  if (v.IsHolding<VtVec2dArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtVec2dArray>()));
+  if (v.IsHolding<VtVec4dArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtVec4dArray>()));
+  if (v.IsHolding<VtDoubleArray>())
+    return VtValue(
+        _RefineArray(refiner, level, mode, v.UncheckedGet<VtDoubleArray>()));
+  // Unsupported element type (e.g. integer ids): drop it.
+  // Returning the coarse array unchanged would bind a vertex/varying attribute
+  // shorter than the refined vertex count and read out of bounds at render
+  // time.
+  return VtValue();
+}
+
+} // namespace
+
+std::unique_ptr<HdAnariSubdivision> HdAnariSubdivision::Create(
+    const HdMeshTopology &topology, int refineLevel)
+{
+  if (refineLevel <= 0)
+    return nullptr;
+  if (topology.GetScheme() == PxOsdOpenSubdivTokens->none)
+    return nullptr;
+  if (!topology.GetGeomSubsets().empty())
+    return nullptr;
+
+  PxOsdTopologyRefinerSharedPtr refiner =
+      PxOsdRefinerFactory::Create(topology.GetPxOsdMeshTopology());
+  if (!refiner)
+    return nullptr;
+
+  Far::TopologyRefiner::UniformOptions options(refineLevel);
+  options.fullTopologyInLastLevel = true;
+  refiner->RefineUniform(options);
+
+  const Far::TopologyLevel &last = refiner->GetLevel(refineLevel);
+  const int numFaces = last.GetNumFaces();
+  VtIntArray faceVertexCounts(numFaces);
+  VtIntArray faceVertexIndices;
+  faceVertexIndices.reserve(last.GetNumFaceVertices());
+  for (int f = 0; f < numFaces; ++f) {
+    const Far::ConstIndexArray verts = last.GetFaceVertices(f);
+    faceVertexCounts[f] = verts.size();
+    for (int i = 0; i < verts.size(); ++i)
+      faceVertexIndices.push_back(verts[i]);
+  }
+
+  std::unique_ptr<HdAnariSubdivision> result(new HdAnariSubdivision);
+  result->refiner_ = refiner;
+  result->level_ = refineLevel;
+  result->refinedTopology_ = HdMeshTopology(PxOsdOpenSubdivTokens->none,
+      topology.GetOrientation(),
+      faceVertexCounts,
+      faceVertexIndices);
+  return result;
+}
+
+VtValue HdAnariSubdivision::Refine(
+    const VtValue &value, HdInterpolation interpolation) const
+{
+  if (!refiner_)
+    return value;
+
+  switch (interpolation) {
+  case HdInterpolationConstant:
+    return value; // one value for the whole prim, unchanged by refinement
+  case HdInterpolationVertex:
+    return _RefineTyped(*refiner_, level_, _Mode::Vertex, value);
+  case HdInterpolationVarying:
+    return _RefineTyped(*refiner_, level_, _Mode::Varying, value);
+  case HdInterpolationUniform:
+    return _RefineTyped(*refiner_, level_, _Mode::Uniform, value);
+  default:
+    // Face-varying and instance interpolation are not refined in v1.
+    return VtValue();
+  }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/rd/subdivision.h
+++ b/src/hdanari/rd/subdivision.h
@@ -1,0 +1,48 @@
+// Copyright 2024-2026 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pxr/base/vt/value.h>
+#include <pxr/imaging/hd/enums.h>
+#include <pxr/imaging/hd/meshTopology.h>
+#include <pxr/imaging/pxOsd/refinerFactory.h>
+#include <pxr/pxr.h>
+
+#include <memory>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// Uniform OpenSubdiv refinement of a mesh, driven by the USD complexity-derived
+// refine level (HdDisplayStyle::refineLevel). Refines the subdivision control
+// cage into a denser polygonal mesh and interpolates primvars so they stay
+// consistent with the refined vertices and faces.
+//
+// v1 limitations: uniform refinement only; face-varying primvars are not
+// refined (Refine returns an empty VtValue for them); meshes carrying geom
+// subsets are not refined (Create returns null).
+class HdAnariSubdivision
+{
+ public:
+  // Returns null when the mesh should not be refined: non-positive level, no
+  // subdivision scheme, or geom subsets present.
+  static std::unique_ptr<HdAnariSubdivision> Create(
+      const HdMeshTopology &topology, int refineLevel);
+
+  // Refined polygonal topology (subdivision scheme cleared to "none").
+  const HdMeshTopology &refinedTopology() const { return refinedTopology_; }
+
+  // Interpolate a coarse primvar value onto the refined mesh. Constant values
+  // pass through unchanged; face-varying (and unsupported element types) return
+  // an empty VtValue.
+  VtValue Refine(const VtValue &value, HdInterpolation interpolation) const;
+
+ private:
+  HdAnariSubdivision() = default;
+
+  PxOsdTopologyRefinerSharedPtr refiner_;
+  HdMeshTopology refinedTopology_;
+  int level_ = 0;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdanari/sdr/mdlNodes.cpp
+++ b/src/hdanari/sdr/mdlNodes.cpp
@@ -91,6 +91,13 @@ MdlSdrShaderNode *MdlSdrShaderNode::ParseSdrDiscoveryResult(
   TfScoped releaseFunctionDefinition(
       [&functionDefinition]() { functionDefinition.reset(); });
 
+  // getFunctionDefinition returns null when the module compiled but the
+  // requested function/material is absent -- e.g. a material whose body failed
+  // to compile (unresolved imports, missing textures). Bail instead of
+  // dereferencing null.
+  if (!functionDefinition)
+    return nullptr;
+
   if (functionDefinition->is_material()) {
     return new MdlMaterialSdrNode(
         discoveryResult, functionDefinition.get(), transaction.get());
@@ -275,8 +282,6 @@ SdrShaderPropertyUniquePtrVec MdlFunctionSdrNode::GetShaderProperties(
     mi::neuraylib::ITransaction *transaction)
 {
   SdrShaderPropertyUniquePtrVec properties;
-
-  return properties;
 
   // handle return type
   auto returnType =

--- a/src/hdanari/sdr/mdlNodes.cpp
+++ b/src/hdanari/sdr/mdlNodes.cpp
@@ -37,8 +37,8 @@ MdlSdrShaderNode *MdlSdrShaderNode::ParseSdrDiscoveryResult(
     const SdrShaderNodeDiscoveryResult &discoveryResult)
 {
   auto registry = HdAnariMdlRegistry::GetInstance();
-  if (!registry)
-    return nullptr;
+  if (!registry || !registry->getINeuray())
+    return nullptr; // registry disabled (no INeuray) -> MDL discovery off
 
   if (discoveryResult.resolvedUri.length() > discoveryResult.uri.length()) {
     // Try and get a meaningful search path from the resolvedUri and uri

--- a/src/hdanari/sdr/mdlNodes.cpp
+++ b/src/hdanari/sdr/mdlNodes.cpp
@@ -283,11 +283,6 @@ SdrShaderPropertyUniquePtrVec MdlFunctionSdrNode::GetShaderProperties(
 {
   SdrShaderPropertyUniquePtrVec properties;
 
-  // handle return type
-  auto returnType =
-      mi::base::make_handle(functionDefinition->get_return_type());
-
-  // Parameters
   auto count = functionDefinition->get_parameter_count();
 
   auto types = mi::base::make_handle(functionDefinition->get_parameter_types());
@@ -296,59 +291,60 @@ SdrShaderPropertyUniquePtrVec MdlFunctionSdrNode::GetShaderProperties(
       mi::base::make_handle(functionDefinition->get_parameter_annotations());
 
   for (mi::Size index = 0; index < count; index++) {
-    auto type =
-        mi::base::make_handle(types->get_type(index)->skip_all_type_aliases());
+    // Every neuray get_*/get_interface returns a retained (+1) pointer; each
+    // must be owned by a handle or it pins the DB element past transaction
+    // close ("still referenced while transaction ... is aborted"). get_type()
+    // and skip_all_type_aliases() each retain, so wrap both -- not just the
+    // skip result.
+    auto rawType = mi::base::make_handle(types->get_type(index));
+    auto type = mi::base::make_handle(rawType->skip_all_type_aliases());
     std::string name = functionDefinition->get_parameter_name(index);
     auto defaultValue =
         mi::base::make_handle(defaults->get_expression(name.c_str()));
     auto annotationBlock =
         mi::base::make_handle(annotationList->get_annotation_block(index));
-    auto annotations = mi::neuraylib::Annotation_wrapper(annotationBlock.get());
+    mi::neuraylib::Annotation_wrapper annotationWrapper(annotationBlock.get());
 
-    mi::neuraylib::Annotation_wrapper annotationWrapper(annotations);
+    // The create* helpers dereference the default expression unconditionally.
+    // A parameter may have no default, or a non-constant one -- skip it rather
+    // than deref a null handle.
+    auto defaultConstant = mi::base::make_handle(defaultValue
+            ? defaultValue
+                  ->get_interface<const mi::neuraylib::IExpression_constant>()
+            : nullptr);
+    if (!defaultConstant)
+      continue;
 
     switch (type->get_kind()) {
-    // case mi::neuraylib::IType::TK_STRING: {
-    //     properties.push_back(
-    //         createScalarInputProperty<mi::neuraylib::IValue_string>(name,
-    //             type->get_interface<const mi::neuraylib::IType_string>(),
-    //             defaultValue->get_interface<const
-    //             mi::neuraylib::IExpression_constant>(), &annotationWrapper
-    //     ));
-    //     break;
-    // }
     case mi::neuraylib::IType::TK_TEXTURE: {
-      properties.push_back(createTextureInputProperty(name,
-          type->get_interface<const mi::neuraylib::IType_texture>(),
-          defaultValue
-              ->get_interface<const mi::neuraylib::IExpression_constant>(),
-          &annotationWrapper));
+      auto textureType = mi::base::make_handle(
+          type->get_interface<const mi::neuraylib::IType_texture>());
+      properties.push_back(createTextureInputProperty(
+          name, textureType.get(), defaultConstant.get(), &annotationWrapper));
       break;
     }
     case mi::neuraylib::IType::TK_BOOL: {
+      auto boolType = mi::base::make_handle(
+          type->get_interface<const mi::neuraylib::IType_bool>());
       properties.push_back(
-          createScalarInputProperty<mi::neuraylib::IValue_bool>(name,
-              type->get_interface<const mi::neuraylib::IType_bool>(),
-              defaultValue
-                  ->get_interface<const mi::neuraylib::IExpression_constant>(),
-              &annotationWrapper));
+          createScalarInputProperty<mi::neuraylib::IValue_bool>(
+              name, boolType.get(), defaultConstant.get(), &annotationWrapper));
       break;
     }
     case mi::neuraylib::IType::TK_INT: {
-      properties.push_back(
-          createScalarInputProperty<mi::neuraylib::IValue_int>(name,
-              type->get_interface<const mi::neuraylib::IType_int>(),
-              defaultValue
-                  ->get_interface<const mi::neuraylib::IExpression_constant>(),
-              &annotationWrapper));
+      auto intType = mi::base::make_handle(
+          type->get_interface<const mi::neuraylib::IType_int>());
+      properties.push_back(createScalarInputProperty<mi::neuraylib::IValue_int>(
+          name, intType.get(), defaultConstant.get(), &annotationWrapper));
       break;
     }
     case mi::neuraylib::IType::TK_FLOAT: {
+      auto floatType = mi::base::make_handle(
+          type->get_interface<const mi::neuraylib::IType_float>());
       properties.push_back(
           createScalarInputProperty<mi::neuraylib::IValue_float>(name,
-              type->get_interface<const mi::neuraylib::IType_float>(),
-              defaultValue
-                  ->get_interface<const mi::neuraylib::IExpression_constant>(),
+              floatType.get(),
+              defaultConstant.get(),
               &annotationWrapper));
       break;
     }


### PR DESCRIPTION
- Bring up MDL material support in experimental hdAnari OpenUSD delegate on VisRTX backend. Fix delegate lifecycle, material sync, geometry, lighting, render-settings paths MDL + real USD assets exposed.
- Make batch render (usdrecord) terminate: frames report convergence + sample progress
- Renderer settings/sample limits from ANARI introspection, not hardcoded descriptors. Plus a few others postprocessing (exposure for instance) to help dealing with possibly mis-interpreted lighting description.
- Correctness/robustness on heavy scenes (OldAttic, Brownstone, AEC restaurant, clock/elevator)
- Add support for OpenSubdiv tessellation so hdanari honour the geometry Complexity parameter
